### PR TITLE
Chore/phase 0 foundations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# Vite dev server origin for the React SPA; referenced by config/cors.php.
+FRONTEND_URL=http://localhost:5173
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,6 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
-# Vite dev server origin for the React SPA; referenced by config/cors.php.
-FRONTEND_URL=http://localhost:5173
-
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ yarn-error.log
 /boost.json
 /CLAUDE.md
 /CONTRIBUTING.md
+/ROADMAP.md

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,13 +16,14 @@ use Laravel\Sanctum\HasApiTokens;
  * @property int $id
  * @property string $name
  * @property string $email
+ * @property string $role
  * @property Carbon|null $email_verified_at
  * @property string $password
  * @property string|null $remember_token
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
-#[Fillable(['name', 'email', 'password'])]
+#[Fillable(['name', 'email', 'role', 'password'])]
 #[Hidden(['password', 'remember_token'])]
 class User extends Authenticatable
 {

--- a/config/cors.php
+++ b/config/cors.php
@@ -20,7 +20,7 @@ return [
     // TODO(phase-11): restrict to the real frontend origin(s) before production.
     // Dev uses the Vite dev server at http://localhost:5173; '*' is a temporary
     // convenience for local development only and MUST NOT ship to production.
-    'allowed_origins' => ['*'],
+    'allowed_origins' => ['*', 'http://localhost:5173', 'http://127.0.0.1:5173'],
 
     'allowed_origins_patterns' => [],
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Stateless bearer-token API (Sanctum) — there is no cookie/session or CSRF
+    | layer between the React SPA and this API, so 'supports_credentials' stays
+    | false. Only the versioned API surface is exposed to cross-origin requests.
+    |
+    */
+
+    'paths' => ['api/*'],
+
+    'allowed_methods' => ['*'],
+
+    // TODO(phase-11): restrict to the real frontend origin(s) before production.
+    // Dev uses the Vite dev server at http://localhost:5173; '*' is a temporary
+    // convenience for local development only and MUST NOT ship to production.
+    'allowed_origins' => ['*'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => false,
+
+];

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->enum('role', ['cleaner', 'employer', 'moderator', 'admin'])->default('cleaner')->index();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,4 +3,6 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
+Route::prefix('v1')->group(function (): void {
+    Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
+});


### PR DESCRIPTION
## Summary

Backend Phase 0 foundations: versions the API under `/api/v1`, publishes CORS config for the bearer-token SPA, adds the `role` column to `users`, and keeps local-only working docs out of git.

## Changes

- Version all API routes under `/api/v1` (`routes/api.php`)
- Publish `config/cors.php` scoped to `api/*`, `supports_credentials: false` (stateless bearer-token auth, no CSRF layer), `allowed_origins` currently includes `'*'` alongside explicit Vite dev origins (`http://localhost:5173`, `http://127.0.0.1:5173`)
- Add a `role` enum column (`cleaner`/`employer`/`moderator`/`admin`, default `cleaner`, indexed) to the `create_users_table` migration, exposed on `User`'s fillable/property docblock
- Ignore `ROADMAP.md` in git (local working doc, matching the already-ignored `CLAUDE.md`/`CONTRIBUTING.md`)
- Drop `FRONTEND_URL` from `.env.example` (kept the example limited to real config, not dev-only values)

## Testing

- `php artisan test --compact` — 2 passed
- `vendor/bin/pint --test --format agent` — passed
- Manual, via `php artisan serve` + curl:
  - `OPTIONS /api/v1/user` with `Origin: http://localhost:5173` → `204` with CORS header present
  - `GET /api/v1/user` (unauthenticated) → `401` JSON

## Notes

- Local dev DB is MySQL/MariaDB; Pest runs against in-memory sqlite via `phpunit.xml`, unaffected