### PR TITLE
Feat: Add registration, login, verification, and password reset

### DIFF
--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case Cleaner = 'cleaner';
+    case Employer = 'employer';
+    case Moderator = 'moderator';
+    case Admin = 'admin';
+
+    /**
+     * Roles a user may choose when self-registering. Moderator and admin
+     * accounts are provisioned by an admin, never through registration.
+     *
+     * @return array<int, self>
+     */
+    public static function selfRegisterable(): array
+    {
+        return [self::Cleaner, self::Employer];
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Api/V1/Auth/EmailVerificationNotificationController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EmailVerificationNotificationController extends Controller
+{
+    public function store(Request $request): JsonResponse
+    {
+        if ($request->user()->hasVerifiedEmail()) {
+            return response()->json(['message' => 'Email already verified.']);
+        }
+
+        $request->user()->sendEmailVerificationNotification();
+
+        return response()->json(['message' => 'Verification link sent.']);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/V1/Auth/LoginController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\LoginRequest;
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class LoginController extends Controller
+{
+    public function store(LoginRequest $request): JsonResponse
+    {
+        $user = User::where('email', $request->validated('email'))->first();
+
+        if (! $user || ! Hash::check($request->validated('password'), $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => [__('auth.failed')],
+            ]);
+        }
+
+        return response()->json([
+            'token' => $user->createToken('auth')->plainTextToken,
+            'user' => new UserResource($user),
+        ]);
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out.']);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Api/V1/Auth/NewPasswordController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ResetPasswordRequest;
+use App\Models\User;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class NewPasswordController extends Controller
+{
+    public function store(ResetPasswordRequest $request): JsonResponse
+    {
+        $status = Password::reset(
+            $request->validated(),
+            function (User $user, string $password) {
+                $user->forceFill(['password' => $password])->setRememberToken(Str::random(60));
+                $user->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        if ($status !== Password::PasswordReset) {
+            throw ValidationException::withMessages(['email' => [__($status)]]);
+        }
+
+        return response()->json(['message' => __($status)]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Api/V1/Auth/PasswordResetLinkController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ForgotPasswordRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+
+class PasswordResetLinkController extends Controller
+{
+    public function store(ForgotPasswordRequest $request): JsonResponse
+    {
+        $status = Password::sendResetLink($request->validated());
+
+        if ($status !== Password::ResetLinkSent) {
+            throw ValidationException::withMessages(['email' => [__($status)]]);
+        }
+
+        return response()->json(['message' => __($status)]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/V1/Auth/RegisterController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterRequest;
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Http\JsonResponse;
+
+class RegisterController extends Controller
+{
+    public function store(RegisterRequest $request): JsonResponse
+    {
+        $user = User::create($request->validated());
+
+        event(new Registered($user));
+
+        return response()->json([
+            'token' => $user->createToken('auth')->plainTextToken,
+            'user' => new UserResource($user),
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Api/V1/Auth/VerifyEmailController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Auth\Events\Verified;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class VerifyEmailController extends Controller
+{
+    public function __invoke(Request $request, int $id, string $hash): RedirectResponse
+    {
+        $user = User::findOrFail($id);
+
+        if (! hash_equals($hash, sha1($user->getEmailForVerification()))) {
+            abort(403, 'Invalid verification link.');
+        }
+
+        if (! $user->hasVerifiedEmail()) {
+            $user->markEmailAsVerified();
+
+            event(new Verified($user));
+        }
+
+        return redirect()->away(config('cleanhub.frontend_url').'?verified=1');
+    }
+}

--- a/app/Http/Requests/Auth/ForgotPasswordRequest.php
+++ b/app/Http/Requests/Auth/ForgotPasswordRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)],
+            'password' => ['required', 'confirmed', Password::defaults()],
+            'role' => ['required', Rule::enum(UserRole::class)->only(UserRole::selfRegisterable())],
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/ResetPasswordRequest.php
+++ b/app/Http/Requests/Auth/ResetPasswordRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class ResetPasswordRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string'],
+            'email' => ['required', 'string', 'email'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin User
+ */
+class UserResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'role' => $this->role->value,
+            'email_verified_at' => $this->email_verified_at,
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\UserRole;
+use App\Notifications\Auth\QueuedVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -16,7 +18,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property int $id
  * @property string $name
  * @property string $email
- * @property string $role
+ * @property UserRole $role
  * @property Carbon|null $email_verified_at
  * @property string $password
  * @property string|null $remember_token
@@ -25,7 +27,7 @@ use Laravel\Sanctum\HasApiTokens;
  */
 #[Fillable(['name', 'email', 'role', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
@@ -40,6 +42,32 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
+    }
+
+    public function isCleaner(): bool
+    {
+        return $this->role === UserRole::Cleaner;
+    }
+
+    public function isEmployer(): bool
+    {
+        return $this->role === UserRole::Employer;
+    }
+
+    public function isModerator(): bool
+    {
+        return $this->role === UserRole::Moderator;
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->role === UserRole::Admin;
+    }
+
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new QueuedVerifyEmail);
     }
 }

--- a/app/Notifications/Auth/QueuedVerifyEmail.php
+++ b/app/Notifications/Auth/QueuedVerifyEmail.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Notifications\Auth;
+
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class QueuedVerifyEmail extends VerifyEmail implements ShouldQueue
+{
+    use Queueable;
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Skeleton policy. The admin bypasses every check via the Gate::before hook
+ * in AppServiceProvider; concrete per-role rules for user management land with
+ * the admin panel in a later stage.
+ */
+class UserPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    public function view(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    public function update(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    public function restore(User $user, User $model): bool
+    {
+        return false;
+    }
+
+    public function forceDelete(User $user, User $model): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,12 @@
 
 namespace App\Providers;
 
+use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 
@@ -24,6 +27,19 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
+        $this->configureAuth();
+    }
+
+    /**
+     * Grant the admin every ability and point auth emails at the SPA.
+     */
+    protected function configureAuth(): void
+    {
+        Gate::before(fn (User $user): ?bool => $user->isAdmin() ? true : null);
+
+        ResetPassword::createUrlUsing(fn (User $user, string $token): string => config('cleanhub.frontend_url')
+            .'/reset-password?token='.$token
+            .'&email='.urlencode($user->getEmailForPasswordReset()));
     }
 
     /**

--- a/config/cleanhub.php
+++ b/config/cleanhub.php
@@ -1,0 +1,36 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Frontend URL
+    |--------------------------------------------------------------------------
+    |
+    | Base URL of the React SPA. Used to build the links emailed for password
+    | reset and to redirect to after email verification. Set FRONTEND_URL in
+    | the environment for staging/production; the default targets the local
+    | Vite dev server.
+    |
+    */
+
+    'frontend_url' => env('FRONTEND_URL', 'http://localhost:5173'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Account
+    |--------------------------------------------------------------------------
+    |
+    | Credentials for the single admin account provisioned by AdminUserSeeder.
+    | Exactly one admin ever exists and is never self-registered. Override
+    | ADMIN_* in the environment before seeding a real deployment.
+    |
+    */
+
+    'admin' => [
+        'name' => env('ADMIN_NAME', 'CleanHub Admin'),
+        'email' => env('ADMIN_EMAIL', 'admin@cleanhub.test'),
+        'password' => env('ADMIN_PASSWORD', 'password'),
+    ],
+
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -27,6 +28,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'role' => UserRole::Cleaner,
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
@@ -41,5 +43,25 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    public function cleaner(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => UserRole::Cleaner]);
+    }
+
+    public function employer(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => UserRole::Employer]);
+    }
+
+    public function moderator(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => UserRole::Moderator]);
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => UserRole::Admin]);
     }
 }

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\UserRole;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class AdminUserSeeder extends Seeder
+{
+    /**
+     * Provision the single admin account. Keyed on the admin role so it stays
+     * idempotent and never creates a second admin.
+     */
+    public function run(): void
+    {
+        User::firstOrCreate(
+            ['role' => UserRole::Admin],
+            [
+                'name' => config('cleanhub.admin.name'),
+                'email' => config('cleanhub.admin.email'),
+                'password' => config('cleanhub.admin.password'),
+                'email_verified_at' => now(),
+            ],
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,11 +14,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(AdminUserSeeder::class);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,29 @@
 <?php
 
+use App\Http\Controllers\Api\V1\Auth\EmailVerificationNotificationController;
+use App\Http\Controllers\Api\V1\Auth\LoginController;
+use App\Http\Controllers\Api\V1\Auth\NewPasswordController;
+use App\Http\Controllers\Api\V1\Auth\PasswordResetLinkController;
+use App\Http\Controllers\Api\V1\Auth\RegisterController;
+use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function (): void {
+    Route::prefix('auth')->group(function (): void {
+        Route::post('register', [RegisterController::class, 'store']);
+        Route::post('login', [LoginController::class, 'store']);
+        Route::post('forgot-password', [PasswordResetLinkController::class, 'store']);
+        Route::post('reset-password', [NewPasswordController::class, 'store']);
+        Route::get('verify-email/{id}/{hash}', VerifyEmailController::class)
+            ->middleware('signed')
+            ->name('verification.verify');
+
+        Route::middleware('auth:sanctum')->group(function (): void {
+            Route::post('logout', [LoginController::class, 'destroy']);
+            Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store']);
+        });
+    });
+
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
 });

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+
+test('a user can log in and receive a token', function () {
+    $user = User::factory()->create();
+
+    $response = $this->postJson('/api/v1/auth/login', [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['token', 'user' => ['id', 'name', 'email', 'role', 'email_verified_at']])
+        ->assertJsonPath('user.email', $user->email);
+});
+
+test('login fails with an incorrect password', function () {
+    $user = User::factory()->create();
+
+    $response = $this->postJson('/api/v1/auth/login', [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('email');
+});
+
+test('a user can log out and the current token is revoked', function () {
+    $user = User::factory()->create();
+    $token = $user->createToken('auth')->plainTextToken;
+
+    $this->withToken($token)->postJson('/api/v1/auth/logout')->assertOk();
+
+    expect($user->tokens()->count())->toBe(0);
+});
+
+test('logout requires authentication', function () {
+    $this->postJson('/api/v1/auth/logout')->assertUnauthorized();
+});

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\Auth\QueuedVerifyEmail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Laravel\Sanctum\Sanctum;
+
+test('a user can verify their email via a signed link', function () {
+    $user = User::factory()->unverified()->create();
+
+    $url = URL::temporarySignedRoute('verification.verify', now()->addMinutes(60), [
+        'id' => $user->id,
+        'hash' => sha1($user->email),
+    ]);
+
+    $this->get($url)->assertRedirect(config('cleanhub.frontend_url').'?verified=1');
+
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+});
+
+test('verification fails with an invalid hash', function () {
+    $user = User::factory()->unverified()->create();
+
+    $url = URL::temporarySignedRoute('verification.verify', now()->addMinutes(60), [
+        'id' => $user->id,
+        'hash' => sha1('someone-else@example.com'),
+    ]);
+
+    $this->get($url)->assertForbidden();
+
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
+});
+
+test('verification fails without a valid signature', function () {
+    $user = User::factory()->unverified()->create();
+
+    $this->get("/api/v1/auth/verify-email/{$user->id}/".sha1($user->email))->assertForbidden();
+});
+
+test('an authenticated user can resend the verification email', function () {
+    Notification::fake();
+
+    $user = User::factory()->unverified()->create();
+    Sanctum::actingAs($user);
+
+    $this->postJson('/api/v1/auth/email/verification-notification')->assertOk();
+
+    Notification::assertSentTo($user, QueuedVerifyEmail::class);
+});

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+
+test('a reset link is sent for a known email', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $this->postJson('/api/v1/auth/forgot-password', ['email' => $user->email])->assertOk();
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+test('a user can reset their password with a valid token', function () {
+    $user = User::factory()->create();
+    $token = Password::createToken($user);
+
+    $response = $this->postJson('/api/v1/auth/reset-password', [
+        'token' => $token,
+        'email' => $user->email,
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ]);
+
+    $response->assertOk();
+
+    expect(Hash::check('new-password', $user->fresh()->password))->toBeTrue();
+});
+
+test('password reset fails with an invalid token', function () {
+    $user = User::factory()->create();
+
+    $response = $this->postJson('/api/v1/auth/reset-password', [
+        'token' => 'invalid-token',
+        'email' => $user->email,
+        'password' => 'new-password',
+        'password_confirmation' => 'new-password',
+    ]);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('email');
+});

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Models\User;
+use App\Notifications\Auth\QueuedVerifyEmail;
+use Illuminate\Support\Facades\Notification;
+
+test('a cleaner can register and receive a token', function () {
+    Notification::fake();
+
+    $response = $this->postJson('/api/v1/auth/register', [
+        'name' => 'Jane Cleaner',
+        'email' => 'jane@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'role' => 'cleaner',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonStructure(['token', 'user' => ['id', 'name', 'email', 'role', 'email_verified_at']])
+        ->assertJsonPath('user.role', 'cleaner')
+        ->assertJsonPath('user.email_verified_at', null);
+
+    $user = User::where('email', 'jane@example.com')->first();
+
+    expect($user)->not->toBeNull()
+        ->and($user->role)->toBe(UserRole::Cleaner);
+
+    Notification::assertSentTo($user, QueuedVerifyEmail::class);
+});
+
+test('an employer can register', function () {
+    $response = $this->postJson('/api/v1/auth/register', [
+        'name' => 'Acme Cleaning Co',
+        'email' => 'hr@acme.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'role' => 'employer',
+    ]);
+
+    $response->assertCreated()->assertJsonPath('user.role', 'employer');
+});
+
+test('registration rejects privileged roles', function (string $role) {
+    $response = $this->postJson('/api/v1/auth/register', [
+        'name' => 'Sneaky User',
+        'email' => 'sneaky@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'role' => $role,
+    ]);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('role');
+
+    expect(User::where('email', 'sneaky@example.com')->exists())->toBeFalse();
+})->with(['moderator', 'admin']);
+
+test('registration rejects a duplicate email', function () {
+    User::factory()->create(['email' => 'taken@example.com']);
+
+    $response = $this->postJson('/api/v1/auth/register', [
+        'name' => 'Duplicate',
+        'email' => 'taken@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+        'role' => 'cleaner',
+    ]);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('email');
+});
+
+test('registration requires a matching password confirmation', function () {
+    $response = $this->postJson('/api/v1/auth/register', [
+        'name' => 'No Confirm',
+        'email' => 'noconfirm@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'different',
+        'role' => 'cleaner',
+    ]);
+
+    $response->assertUnprocessable()->assertJsonValidationErrors('password');
+});


### PR DESCRIPTION
## Summary

Adds the full authentication surface: registration (cleaner/employer only), login/logout via Sanctum tokens, queued email verification, password reset, a single idempotent admin seeder, and the role-authorization scaffolding those endpoints sit on. No schema changes — the `users.role` column already shipped in the previous merge.

## Changes

### Major
- **Registration** (`POST /api/v1/auth/register`) — `RegisterRequest` restricts `role` to `cleaner`/`employer` via `UserRole::selfRegisterable()`; moderator/admin rejected with 422. Fires `Registered`, returns a Sanctum token + user. *Why*: moderator/admin accounts must never be self-created.
- **Login/Logout** (`POST /api/v1/auth/login`, `POST /api/v1/auth/logout`) — issues/revokes a Sanctum personal access token; bad credentials return 422. *Why*: this is the actual mechanism behind the stateless bearer-token architecture.
- **Email verification** (`GET /api/v1/auth/verify-email/{id}/{hash}`, signed; resend via `POST /api/v1/auth/email/verification-notification`) — `MustVerifyEmail` + a queued `QueuedVerifyEmail` notification. *Why*: verification is required before applying/posting per the feature spec; queued so it doesn't block the request.
- **Password reset** (`POST /api/v1/auth/forgot-password`, `POST /api/v1/auth/reset-password`) — Laravel's built-in broker; reset email links to the SPA's reset route. *Why*: standard forgot-password flow per spec.
- **Single admin seeder** (`AdminUserSeeder`) — idempotent, keyed on the admin role so re-running never creates a second admin. *Why*: exactly one admin account, never self-registered, per spec.

### Minor
- `UserRole` enum (`cleaner`/`employer`/`moderator`/`admin`) with `selfRegisterable()` and `isCleaner`/`isEmployer`/`isModerator`/`isAdmin` helpers, cast on `User`.
- `Gate::before` hook granting the admin role every ability — foundation for future admin-only endpoints, nothing wired to it yet.
- Deny-by-default `UserPolicy` stub — placeholder for later admin-panel authorization, not attached to any route in this branch.
- `UserResource` — shapes the `user` object returned by register/login.
- `config/cleanhub.php` — centralizes the frontend URL (for reset/verification redirects) and admin seed credentials behind env vars instead of hardcoding them.
- Auth routes grouped under the existing `/api/v1/auth` prefix, consistent with the versioning already in place.

## Testing

- `php artisan test --compact` — 19 passed, 61 assertions (4 new feature test files: registration, authentication, email verification, password reset)
- `vendor/bin/pint --test --format agent` — clean
- Cross-repo: the frontend branch (`feat/auth-roles`) smoke-tested these endpoints live via curl against a running `php artisan serve` — register → 201, login → 200, logout with bearer → 200, unauthenticated protected route → 401, bad login → 422 on `errors.email`. All matched the shapes documented below.

## Rollback

- No migrations in this branch — reverting is just reverting the merge commit / not merging, nothing to roll back at the schema level.
- **`AdminUserSeeder` is not self-reversing**: if `php artisan db:seed` was run anywhere, an admin row persists in that database after a code revert. Remove it manually (e.g. via `tinker`) if the seeder shouldn't have run.
- Additive only — no existing route or response shape was changed, so reverting carries no risk to anything already deployed.