### PR TITLE
Feat: Add cleaner and employer profile system

### DIFF
--- a/app/Http/Controllers/Api/V1/CleaningJobCategoryController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobCategoryController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CleaningJobCategoryResource;
+use App\Models\CleaningJobCategory;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class CleaningJobCategoryController extends Controller
+{
+    /**
+     * List the active cleaning categories cleaners choose from and job
+     * browsing filters by. Guest-accessible.
+     */
+    public function index(): AnonymousResourceCollection
+    {
+        $categories = CleaningJobCategory::query()
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get();
+
+        return CleaningJobCategoryResource::collection($categories);
+    }
+}

--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateProfileRequest;
+use App\Http\Resources\CleanerProfileResource;
+use App\Http\Resources\EmployerProfileResource;
+use App\Models\CleanerProfile;
+use App\Models\EmployerProfile;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ProfileController extends Controller
+{
+    /**
+     * Return the authenticated user's own profile, shaped by their role. The
+     * profile row is created on first access so the SPA always has an object
+     * to edit.
+     */
+    public function show(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $resource = match (true) {
+            $user->isCleaner() => $this->cleanerProfile($user),
+            $user->isEmployer() => $this->employerProfile($user),
+            default => throw new NotFoundHttpException('No profile for this account type.'),
+        };
+
+        return $resource->response()->setStatusCode(200);
+    }
+
+    /**
+     * Update the authenticated user's own profile. Multipart request (reached
+     * via POST + `_method=PATCH`); only the fields present are changed.
+     * Uploaded documents are appended to the existing set.
+     */
+    public function update(UpdateProfileRequest $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $resource = $user->isEmployer()
+            ? $this->updateEmployerProfile($request, $user)
+            : $this->updateCleanerProfile($request, $user);
+
+        return $resource->response()->setStatusCode(200);
+    }
+
+    protected function updateCleanerProfile(UpdateProfileRequest $request, User $user): CleanerProfileResource
+    {
+        $profile = $user->cleanerProfile()->firstOrCreate();
+
+        $profile->fill($request->safe()->only(['bio', 'country', 'city', 'languages']));
+
+        if ($request->hasFile('photo')) {
+            $profile->photo_path = $request->file('photo')->store('cleaner-photos', 'public');
+        }
+
+        if ($request->hasFile('documents')) {
+            $profile->documents = $this->appendDocuments($profile, $request->file('documents'), 'cleaner-documents');
+        }
+
+        $profile->save();
+
+        if ($request->has('cleaning_categories')) {
+            $profile->cleaningJobCategories()->sync($request->input('cleaning_categories', []));
+        }
+
+        $profile->load(['user', 'cleaningJobCategories']);
+
+        return new CleanerProfileResource($profile);
+    }
+
+    protected function updateEmployerProfile(UpdateProfileRequest $request, User $user): EmployerProfileResource
+    {
+        $profile = $user->employerProfile()->firstOrCreate();
+
+        $profile->fill($request->safe()->only([
+            'employer_type',
+            'contact_person_name',
+            'contact_person_contact',
+            'country',
+            'city',
+            'address',
+            'about',
+        ]));
+
+        if ($request->hasFile('photo')) {
+            $profile->photo_path = $request->file('photo')->store('employer-photos', 'public');
+        }
+
+        if ($request->hasFile('documents')) {
+            $profile->documents = $this->appendDocuments($profile, $request->file('documents'), 'employer-documents');
+        }
+
+        $profile->save();
+        $profile->load('user');
+
+        return new EmployerProfileResource($profile);
+    }
+
+    /**
+     * Store newly-uploaded PDFs and append them to the profile's existing
+     * document list, preserving each file's original name.
+     *
+     * @param  array<int, UploadedFile>  $files
+     * @return array<int, array{name: string, path: string}>
+     */
+    protected function appendDocuments(CleanerProfile|EmployerProfile $profile, array $files, string $directory): array
+    {
+        $stored = array_map(fn (UploadedFile $file): array => [
+            'name' => $file->getClientOriginalName(),
+            'path' => $file->store($directory, 'public'),
+        ], $files);
+
+        return array_merge($profile->documents ?? [], $stored);
+    }
+
+    protected function cleanerProfile(User $user): CleanerProfileResource
+    {
+        $profile = $user->cleanerProfile()->firstOrCreate();
+        $profile->load(['user', 'cleaningJobCategories']);
+
+        return new CleanerProfileResource($profile);
+    }
+
+    protected function employerProfile(User $user): EmployerProfileResource
+    {
+        $profile = $user->employerProfile()->firstOrCreate();
+        $profile->load('user');
+
+        return new EmployerProfileResource($profile);
+    }
+}

--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ProfileController extends Controller
@@ -57,7 +58,7 @@ class ProfileController extends Controller
         $profile->fill($request->safe()->only(['bio', 'country', 'city', 'languages']));
 
         if ($request->hasFile('photo')) {
-            $profile->photo_path = $request->file('photo')->store('cleaner-photos', 'public');
+            $profile->photo_path = $this->storeOrFail($request->file('photo'), 'cleaner-photos');
         }
 
         if ($request->hasFile('documents')) {
@@ -90,7 +91,7 @@ class ProfileController extends Controller
         ]));
 
         if ($request->hasFile('photo')) {
-            $profile->photo_path = $request->file('photo')->store('employer-photos', 'public');
+            $profile->photo_path = $this->storeOrFail($request->file('photo'), 'employer-photos');
         }
 
         if ($request->hasFile('documents')) {
@@ -114,10 +115,25 @@ class ProfileController extends Controller
     {
         $stored = array_map(fn (UploadedFile $file): array => [
             'name' => $file->getClientOriginalName(),
-            'path' => $file->store($directory, 'public'),
+            'path' => $this->storeOrFail($file, $directory),
         ], $files);
 
         return array_merge($profile->documents ?? [], $stored);
+    }
+
+    /**
+     * Store an uploaded file on the public disk, failing fast if the write
+     * does not succeed (rather than persisting a `false` path).
+     */
+    protected function storeOrFail(UploadedFile $file, string $directory): string
+    {
+        $path = $file->store($directory, 'public');
+
+        if ($path === false) {
+            throw new RuntimeException("Failed to store uploaded file in [{$directory}].");
+        }
+
+        return $path;
     }
 
     protected function cleanerProfile(User $user): CleanerProfileResource

--- a/app/Http/Controllers/Api/V1/PublicProfileController.php
+++ b/app/Http/Controllers/Api/V1/PublicProfileController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\UserRole;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CleanerProfileResource;
+use App\Http\Resources\EmployerProfileResource;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+
+class PublicProfileController extends Controller
+{
+    /**
+     * Show a cleaner's public profile by user id. Any authenticated user may
+     * view it; the owner-only email is excluded for everyone but the owner.
+     */
+    public function cleaner(int $id): CleanerProfileResource
+    {
+        $user = User::where('role', UserRole::Cleaner)->findOrFail($id);
+
+        $profile = $user->cleanerProfile()->with('cleaningJobCategories')->first()
+            ?? $user->cleanerProfile()->make()->setRelation('cleaningJobCategories', new Collection);
+
+        $profile->setRelation('user', $user);
+
+        return new CleanerProfileResource($profile);
+    }
+
+    /**
+     * Show an employer's public profile by user id.
+     */
+    public function employer(int $id): EmployerProfileResource
+    {
+        $user = User::where('role', UserRole::Employer)->findOrFail($id);
+
+        $profile = $user->employerProfile()->first()
+            ?? $user->employerProfile()->make();
+
+        $profile->setRelation('user', $user);
+
+        return new EmployerProfileResource($profile);
+    }
+}

--- a/app/Http/Requests/UpdateProfileRequest.php
+++ b/app/Http/Requests/UpdateProfileRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\MaxWords;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class UpdateProfileRequest extends FormRequest
+{
+    /**
+     * Only cleaners and employers have an editable profile.
+     */
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        return $user->isCleaner() || $user->isEmployer();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return $this->user()->isEmployer()
+            ? $this->employerRules()
+            : $this->cleanerRules();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function cleanerRules(): array
+    {
+        return [
+            'photo' => ['sometimes', 'nullable', File::image()->max(5 * 1024)],
+            'bio' => ['sometimes', 'nullable', 'string', new MaxWords(101)],
+            'country' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'city' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'languages' => ['sometimes', 'nullable', 'array'],
+            'languages.*' => ['string', 'max:255'],
+            'cleaning_categories' => ['sometimes', 'nullable', 'array'],
+            'cleaning_categories.*' => ['integer', Rule::exists('cleaning_job_categories', 'id')->where('is_active', true)],
+            'documents' => ['sometimes', 'nullable', 'array'],
+            'documents.*' => ['file', File::types(['pdf'])->max(10 * 1024)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function employerRules(): array
+    {
+        return [
+            'photo' => ['sometimes', 'nullable', File::image()->max(5 * 1024)],
+            'employer_type' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'contact_person_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'contact_person_contact' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'country' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'city' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'about' => ['sometimes', 'nullable', 'string', 'max:5000'],
+            'documents' => ['sometimes', 'nullable', 'array'],
+            'documents.*' => ['file', File::types(['pdf'])->max(10 * 1024)],
+        ];
+    }
+}

--- a/app/Http/Resources/CleanerProfileResource.php
+++ b/app/Http/Resources/CleanerProfileResource.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\CleanerProfile;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @mixin CleanerProfile
+ */
+class CleanerProfileResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'full_name' => $this->user->name,
+            'email' => $this->when(
+                $request->user()?->id === $this->user_id,
+                fn () => $this->user->email,
+            ),
+            'photo_url' => $this->photo_path ? Storage::disk('public')->url($this->photo_path) : null,
+            'bio' => $this->bio,
+            'country' => $this->country,
+            'city' => $this->city,
+            'cleaning_categories' => CleaningJobCategoryResource::collection(
+                $this->whenLoaded('cleaningJobCategories'),
+            ),
+            'languages' => $this->languages ?? [],
+            'documents' => $this->mapDocuments(),
+            'rating_average' => null,
+            'rating_count' => 0,
+            'completed_jobs_count' => 0,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    /**
+     * @return array<int, array{name: string, url: string}>
+     */
+    protected function mapDocuments(): array
+    {
+        return collect($this->documents ?? [])
+            ->map(fn (array $document): array => [
+                'name' => $document['name'],
+                'url' => Storage::disk('public')->url($document['path']),
+            ])
+            ->all();
+    }
+}

--- a/app/Http/Resources/CleaningJobCategoryResource.php
+++ b/app/Http/Resources/CleaningJobCategoryResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\CleaningJobCategory;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CleaningJobCategory
+ */
+class CleaningJobCategoryResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
+    }
+}

--- a/app/Http/Resources/EmployerProfileResource.php
+++ b/app/Http/Resources/EmployerProfileResource.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\EmployerProfile;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @mixin EmployerProfile
+ */
+class EmployerProfileResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'full_name' => $this->user->name,
+            'email' => $this->when(
+                $request->user()?->id === $this->user_id,
+                fn () => $this->user->email,
+            ),
+            'employer_type' => $this->employer_type,
+            'contact_person_name' => $this->contact_person_name,
+            'contact_person_contact' => $this->contact_person_contact,
+            'country' => $this->country,
+            'city' => $this->city,
+            'address' => $this->address,
+            'about' => $this->about,
+            'photo_url' => $this->photo_path ? Storage::disk('public')->url($this->photo_path) : null,
+            'documents' => $this->mapDocuments(),
+            'rating_average' => null,
+            'rating_count' => 0,
+            'posted_jobs_count' => 0,
+            'completed_jobs_count' => 0,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    /**
+     * @return array<int, array{name: string, url: string}>
+     */
+    protected function mapDocuments(): array
+    {
+        return collect($this->documents ?? [])
+            ->map(fn (array $document): array => [
+                'name' => $document['name'],
+                'url' => Storage::disk('public')->url($document['path']),
+            ])
+            ->all();
+    }
+}

--- a/app/Models/CleanerProfile.php
+++ b/app/Models/CleanerProfile.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\CleanerProfileFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string|null $photo_path
+ * @property string|null $bio
+ * @property string|null $country
+ * @property string|null $city
+ * @property array<int, string>|null $languages
+ * @property array<int, string>|null $documents
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ * @property-read Collection<int, CleaningJobCategory> $cleaningJobCategories
+ */
+#[Fillable([
+    'photo_path',
+    'bio',
+    'country',
+    'city',
+    'languages',
+    'documents',
+])]
+class CleanerProfile extends Model
+{
+    /** @use HasFactory<CleanerProfileFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'languages' => 'array',
+            'documents' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Cleaning categories the cleaner offers, chosen from the admin-managed
+     * cleaning_job_categories lookup table.
+     *
+     * @return BelongsToMany<CleaningJobCategory, $this>
+     */
+    public function cleaningJobCategories(): BelongsToMany
+    {
+        return $this->belongsToMany(CleaningJobCategory::class);
+    }
+}

--- a/app/Models/CleanerProfile.php
+++ b/app/Models/CleanerProfile.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $country
  * @property string|null $city
  * @property array<int, string>|null $languages
- * @property array<int, string>|null $documents
+ * @property array<int, array{name: string, path: string}>|null $documents
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User $user

--- a/app/Models/CleaningJobCategory.php
+++ b/app/Models/CleaningJobCategory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\CleaningJobCategoryFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property bool $is_active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, CleanerProfile> $cleanerProfiles
+ */
+#[Fillable(['name', 'slug', 'is_active'])]
+class CleaningJobCategory extends Model
+{
+    /** @use HasFactory<CleaningJobCategoryFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsToMany<CleanerProfile, $this>
+     */
+    public function cleanerProfiles(): BelongsToMany
+    {
+        return $this->belongsToMany(CleanerProfile::class);
+    }
+}

--- a/app/Models/EmployerProfile.php
+++ b/app/Models/EmployerProfile.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EmployerProfileFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string|null $employer_type
+ * @property string|null $contact_person_name
+ * @property string|null $contact_person_contact
+ * @property string|null $country
+ * @property string|null $city
+ * @property string|null $address
+ * @property string|null $about
+ * @property string|null $photo_path
+ * @property array<int, string>|null $documents
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ */
+#[Fillable([
+    'employer_type',
+    'contact_person_name',
+    'contact_person_contact',
+    'country',
+    'city',
+    'address',
+    'about',
+    'photo_path',
+    'documents',
+])]
+class EmployerProfile extends Model
+{
+    /** @use HasFactory<EmployerProfileFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'documents' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/EmployerProfile.php
+++ b/app/Models/EmployerProfile.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $address
  * @property string|null $about
  * @property string|null $photo_path
- * @property array<int, string>|null $documents
+ * @property array<int, array{name: string, path: string}>|null $documents
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User $user

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -24,6 +25,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $remember_token
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property-read CleanerProfile|null $cleanerProfile
+ * @property-read EmployerProfile|null $employerProfile
  */
 #[Fillable(['name', 'email', 'role', 'password'])]
 #[Hidden(['password', 'remember_token'])]
@@ -69,5 +72,21 @@ class User extends Authenticatable implements MustVerifyEmail
     public function sendEmailVerificationNotification(): void
     {
         $this->notify(new QueuedVerifyEmail);
+    }
+
+    /**
+     * @return HasOne<CleanerProfile, $this>
+     */
+    public function cleanerProfile(): HasOne
+    {
+        return $this->hasOne(CleanerProfile::class);
+    }
+
+    /**
+     * @return HasOne<EmployerProfile, $this>
+     */
+    public function employerProfile(): HasOne
+    {
+        return $this->hasOne(EmployerProfile::class);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -48,6 +49,8 @@ class AppServiceProvider extends ServiceProvider
     protected function configureDefaults(): void
     {
         Date::use(CarbonImmutable::class);
+
+        JsonResource::withoutWrapping();
 
         DB::prohibitDestructiveCommands(
             app()->isProduction(),

--- a/app/Rules/MaxWords.php
+++ b/app/Rules/MaxWords.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+/**
+ * Caps a string at a maximum word count. Words are counted the same way the
+ * frontend's live counter does: trim, split on runs of whitespace, drop empty
+ * tokens. The cap is inclusive (exactly `$max` words passes).
+ */
+class MaxWords implements ValidationRule
+{
+    public function __construct(private int $max) {}
+
+    /**
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        $wordCount = count(preg_split('/\s+/', trim($value), -1, PREG_SPLIT_NO_EMPTY));
+
+        if ($wordCount > $this->max) {
+            $fail("The :attribute may not be longer than {$this->max} words.");
+        }
+    }
+}

--- a/app/Rules/MaxWords.php
+++ b/app/Rules/MaxWords.php
@@ -24,9 +24,13 @@ class MaxWords implements ValidationRule
             return;
         }
 
-        $wordCount = count(preg_split('/\s+/', trim($value), -1, PREG_SPLIT_NO_EMPTY));
+        $words = preg_split('/\s+/', trim($value), -1, PREG_SPLIT_NO_EMPTY);
 
-        if ($wordCount > $this->max) {
+        if ($words === false) {
+            return;
+        }
+
+        if (count($words) > $this->max) {
             $fail("The :attribute may not be longer than {$this->max} words.");
         }
     }

--- a/database/factories/CleanerProfileFactory.php
+++ b/database/factories/CleanerProfileFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UserRole;
+use App\Models\CleanerProfile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CleanerProfile>
+ */
+class CleanerProfileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->state(['role' => UserRole::Cleaner]),
+            'photo_path' => null,
+            'bio' => fake()->sentence(),
+            'country' => fake()->country(),
+            'city' => fake()->city(),
+            'languages' => fake()->randomElements(['english', 'spanish', 'french', 'german'], 2),
+            'documents' => [],
+        ];
+    }
+}

--- a/database/factories/CleaningJobCategoryFactory.php
+++ b/database/factories/CleaningJobCategoryFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CleaningJobCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<CleaningJobCategory>
+ */
+class CleaningJobCategoryFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'name' => Str::title($name),
+            'slug' => Str::slug($name),
+            'is_active' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => ['is_active' => false]);
+    }
+}

--- a/database/factories/CleaningJobCategoryFactory.php
+++ b/database/factories/CleaningJobCategoryFactory.php
@@ -16,7 +16,7 @@ class CleaningJobCategoryFactory extends Factory
      */
     public function definition(): array
     {
-        $name = fake()->unique()->words(2, true);
+        $name = fake()->unique()->word();
 
         return [
             'name' => Str::title($name),

--- a/database/factories/EmployerProfileFactory.php
+++ b/database/factories/EmployerProfileFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UserRole;
+use App\Models\EmployerProfile;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EmployerProfile>
+ */
+class EmployerProfileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->state(['role' => UserRole::Employer]),
+            'employer_type' => fake()->randomElement(['individual', 'company', 'agency', 'property_owner', 'facility_manager', 'other']),
+            'contact_person_name' => fake()->name(),
+            'contact_person_contact' => fake()->email(),
+            'country' => fake()->country(),
+            'city' => fake()->city(),
+            'address' => fake()->streetAddress(),
+            'about' => fake()->paragraph(),
+            'photo_path' => null,
+            'documents' => [],
+        ];
+    }
+}

--- a/database/migrations/2026_07_20_071026_create_cleaner_profiles_table.php
+++ b/database/migrations/2026_07_20_071026_create_cleaner_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaner_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('photo_path')->nullable();
+            $table->text('bio')->nullable();
+            $table->string('country')->nullable();
+            $table->string('city')->nullable();
+            $table->json('languages')->nullable();
+            $table->json('documents')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaner_profiles');
+    }
+};

--- a/database/migrations/2026_07_20_071027_create_employer_profiles_table.php
+++ b/database/migrations/2026_07_20_071027_create_employer_profiles_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('employer_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('employer_type')->nullable();
+            $table->string('contact_person_name')->nullable();
+            $table->string('contact_person_contact')->nullable();
+            $table->string('country')->nullable();
+            $table->string('city')->nullable();
+            $table->string('address')->nullable();
+            $table->text('about')->nullable();
+            $table->string('photo_path')->nullable();
+            $table->json('documents')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('employer_profiles');
+    }
+};

--- a/database/migrations/2026_07_20_114710_create_cleaning_job_categories_table.php
+++ b/database/migrations/2026_07_20_114710_create_cleaning_job_categories_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaning_job_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->boolean('is_active')->default(true)->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaning_job_categories');
+    }
+};

--- a/database/migrations/2026_07_20_114711_create_cleaner_profile_cleaning_job_category_table.php
+++ b/database/migrations/2026_07_20_114711_create_cleaner_profile_cleaning_job_category_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaner_profile_cleaning_job_category', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cleaner_profile_id')
+                ->constrained(indexName: 'cpcjc_profile_fk')
+                ->cascadeOnDelete();
+            $table->foreignId('cleaning_job_category_id')
+                ->constrained(indexName: 'cpcjc_category_fk')
+                ->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['cleaner_profile_id', 'cleaning_job_category_id'], 'cpcjc_pair_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaner_profile_cleaning_job_category');
+    }
+};

--- a/database/seeders/CleaningJobCategorySeeder.php
+++ b/database/seeders/CleaningJobCategorySeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\CleaningJobCategory;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class CleaningJobCategorySeeder extends Seeder
+{
+    /**
+     * Seed the initial admin-managed cleaning categories. Idempotent (keyed on
+     * slug) so it can run repeatedly without duplicating rows.
+     */
+    public function run(): void
+    {
+        $names = [
+            'Residential',
+            'Hotel',
+            'Hospital',
+            'Office',
+            'Factory',
+            'Public Space',
+            'Research Facility',
+            'Event Cleanup',
+        ];
+
+        foreach ($names as $name) {
+            CleaningJobCategory::firstOrCreate(
+                ['slug' => Str::slug($name)],
+                ['name' => $name, 'is_active' => true],
+            );
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,6 +14,13 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(AdminUserSeeder::class);
+        $this->call([
+            AdminUserSeeder::class,
+            CleaningJobCategorySeeder::class,
+        ]);
+
+        if (! app()->environment('production')) {
+            $this->call(DemoProfileSeeder::class);
+        }
     }
 }

--- a/database/seeders/DemoProfileSeeder.php
+++ b/database/seeders/DemoProfileSeeder.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\UserRole;
+use App\Models\CleaningJobCategory;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Dev-only demo data: a handful of fully-populated cleaner and employer
+ * profiles so the frontend can develop against real seeded records instead of
+ * mocks. Idempotent — keyed on email — so it can run repeatedly.
+ */
+class DemoProfileSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categoriesBySlug = CleaningJobCategory::pluck('id', 'slug');
+
+        $cleaners = [
+            [
+                'name' => 'Jane Dela Cruz',
+                'email' => 'cleaner1@demo.test',
+                'profile' => [
+                    'bio' => 'Detail-oriented residential and office cleaner with eight years of experience.',
+                    'country' => 'Philippines',
+                    'city' => 'Cebu City',
+                    'languages' => ['english', 'tagalog', 'cebuano'],
+                ],
+                'categories' => ['residential', 'office'],
+            ],
+            [
+                'name' => 'Marco Bianchi',
+                'email' => 'cleaner2@demo.test',
+                'profile' => [
+                    'bio' => 'Hotel and hospital sanitation specialist, trained in medical-grade disinfection.',
+                    'country' => 'Italy',
+                    'city' => 'Milan',
+                    'languages' => ['english', 'italian'],
+                ],
+                'categories' => ['hotel', 'hospital'],
+            ],
+            [
+                'name' => 'Aisha Rahman',
+                'email' => 'cleaner3@demo.test',
+                'profile' => [
+                    'bio' => 'Post-event and factory floor cleanup, comfortable with large teams and tight turnarounds.',
+                    'country' => 'United Arab Emirates',
+                    'city' => 'Dubai',
+                    'languages' => ['english', 'arabic'],
+                ],
+                'categories' => ['event-cleanup', 'factory', 'public-space'],
+            ],
+        ];
+
+        foreach ($cleaners as $data) {
+            $user = User::firstOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'role' => UserRole::Cleaner,
+                    'password' => 'password',
+                    'email_verified_at' => now(),
+                ],
+            );
+
+            $profile = $user->cleanerProfile()->firstOrCreate([], $data['profile']);
+
+            $categoryIds = $categoriesBySlug
+                ->only($data['categories'])
+                ->values()
+                ->all();
+
+            $profile->cleaningJobCategories()->sync($categoryIds);
+        }
+
+        $employers = [
+            [
+                'name' => 'Sparkle Facilities Inc.',
+                'email' => 'employer1@demo.test',
+                'profile' => [
+                    'employer_type' => 'company',
+                    'contact_person_name' => 'Maria Reyes',
+                    'contact_person_contact' => 'maria@sparkle.test',
+                    'country' => 'Philippines',
+                    'city' => 'Manila',
+                    'address' => '123 Ayala Avenue, Makati',
+                    'about' => 'Commercial cleaning contractor servicing offices and malls across Metro Manila.',
+                ],
+            ],
+            [
+                'name' => 'Green Hotel Group',
+                'email' => 'employer2@demo.test',
+                'profile' => [
+                    'employer_type' => 'agency',
+                    'contact_person_name' => 'Tom Becker',
+                    'contact_person_contact' => '+49 151 2345678',
+                    'country' => 'Germany',
+                    'city' => 'Berlin',
+                    'address' => null,
+                    'about' => 'Boutique hotel chain hiring housekeeping staff for seasonal peaks.',
+                ],
+            ],
+            [
+                'name' => 'Robert Santos',
+                'email' => 'employer3@demo.test',
+                'profile' => [
+                    'employer_type' => 'individual',
+                    'contact_person_name' => 'Robert Santos',
+                    'contact_person_contact' => 'robert.santos@demo.test',
+                    'country' => 'Philippines',
+                    'city' => 'Davao City',
+                    'address' => null,
+                    'about' => 'Homeowner looking for reliable recurring residential cleaning help.',
+                ],
+            ],
+        ];
+
+        foreach ($employers as $data) {
+            $user = User::firstOrCreate(
+                ['email' => $data['email']],
+                [
+                    'name' => $data['name'],
+                    'role' => UserRole::Employer,
+                    'password' => 'password',
+                    'email_verified_at' => now(),
+                ],
+            );
+
+            $user->employerProfile()->firstOrCreate([], $data['profile']);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
+use App\Http\Controllers\Api\V1\ProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -27,6 +28,11 @@ Route::prefix('v1')->group(function (): void {
     });
 
     Route::get('cleaning-job-categories', [CleaningJobCategoryController::class, 'index']);
+
+    Route::middleware('auth:sanctum')->group(function (): void {
+        Route::get('profile', [ProfileController::class, 'show']);
+        Route::patch('profile', [ProfileController::class, 'update']);
+    });
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use App\Http\Controllers\Api\V1\ProfileController;
+use App\Http\Controllers\Api\V1\PublicProfileController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -32,6 +33,9 @@ Route::prefix('v1')->group(function (): void {
     Route::middleware('auth:sanctum')->group(function (): void {
         Route::get('profile', [ProfileController::class, 'show']);
         Route::patch('profile', [ProfileController::class, 'update']);
+
+        Route::get('cleaners/{id}', [PublicProfileController::class, 'cleaner']);
+        Route::get('employers/{id}', [PublicProfileController::class, 'employer']);
     });
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Auth\NewPasswordController;
 use App\Http\Controllers\Api\V1\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
+use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -24,6 +25,8 @@ Route::prefix('v1')->group(function (): void {
             Route::post('email/verification-notification', [EmailVerificationNotificationController::class, 'store']);
         });
     });
+
+    Route::get('cleaning-job-categories', [CleaningJobCategoryController::class, 'index']);
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());
 });

--- a/tests/Feature/CleaningJobCategoryTest.php
+++ b/tests/Feature/CleaningJobCategoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\CleaningJobCategory;
+
+test('guests can list active cleaning categories as a bare array', function () {
+    CleaningJobCategory::factory()->create(['name' => 'Office', 'slug' => 'office']);
+    CleaningJobCategory::factory()->create(['name' => 'Hotel', 'slug' => 'hotel']);
+
+    $response = $this->getJson('/api/v1/cleaning-job-categories');
+
+    $response->assertOk()
+        ->assertJsonCount(2)
+        ->assertJsonStructure([['id', 'name', 'slug']])
+        ->assertJsonPath('0.slug', 'hotel')
+        ->assertJsonPath('1.slug', 'office');
+});
+
+test('inactive categories are excluded from the list', function () {
+    CleaningJobCategory::factory()->create(['slug' => 'active-one']);
+    CleaningJobCategory::factory()->inactive()->create(['slug' => 'hidden-one']);
+
+    $response = $this->getJson('/api/v1/cleaning-job-categories');
+
+    $response->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.slug', 'active-one');
+});

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Models\CleaningJobCategory;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+test('guests cannot read the own-profile endpoint', function () {
+    $this->getJson('/api/v1/profile')->assertUnauthorized();
+});
+
+test('a cleaner reads their own profile including their email', function () {
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/v1/profile');
+
+    $response->assertOk()
+        ->assertJsonPath('user_id', $user->id)
+        ->assertJsonPath('full_name', $user->name)
+        ->assertJsonPath('email', $user->email)
+        ->assertJsonPath('rating_average', null)
+        ->assertJsonPath('completed_jobs_count', 0)
+        ->assertJsonStructure(['id', 'cleaning_categories', 'languages', 'documents', 'photo_url']);
+});
+
+test('an employer reads their own profile shaped for employers', function () {
+    $user = User::factory()->employer()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->getJson('/api/v1/profile');
+
+    $response->assertOk()
+        ->assertJsonPath('user_id', $user->id)
+        ->assertJsonPath('email', $user->email)
+        ->assertJsonStructure(['id', 'employer_type', 'contact_person_name', 'contact_person_contact', 'posted_jobs_count']);
+});
+
+test('reading the own profile creates the profile row on first access', function () {
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+
+    expect($user->cleanerProfile()->exists())->toBeFalse();
+
+    $this->getJson('/api/v1/profile')->assertOk();
+
+    expect($user->cleanerProfile()->exists())->toBeTrue();
+});
+
+test('moderators and admins have no profile', function () {
+    Sanctum::actingAs(User::factory()->moderator()->create());
+    $this->getJson('/api/v1/profile')->assertNotFound();
+
+    Sanctum::actingAs(User::factory()->admin()->create());
+    $this->getJson('/api/v1/profile')->assertNotFound();
+});
+
+test('a cleaner updates their own profile via multipart method spoofing', function () {
+    Storage::fake('public');
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+    $categories = CleaningJobCategory::factory()->count(2)->create();
+
+    $response = $this->post('/api/v1/profile', [
+        '_method' => 'PATCH',
+        'bio' => 'Reliable office cleaner.',
+        'country' => 'Philippines',
+        'city' => 'Cebu',
+        'languages' => ['english', 'cebuano'],
+        'cleaning_categories' => $categories->pluck('id')->all(),
+        'photo' => UploadedFile::fake()->image('me.jpg'),
+        'documents' => [UploadedFile::fake()->create('resume.pdf', 120, 'application/pdf')],
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('bio', 'Reliable office cleaner.')
+        ->assertJsonPath('city', 'Cebu')
+        ->assertJsonCount(2, 'cleaning_categories')
+        ->assertJsonPath('documents.0.name', 'resume.pdf');
+
+    $profile = $user->cleanerProfile()->first();
+    expect($profile->cleaningJobCategories()->count())->toBe(2);
+    Storage::disk('public')->assertExists($profile->photo_path);
+});
+
+test('bio over 101 words is rejected', function () {
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/v1/profile', [
+        '_method' => 'PATCH',
+        'bio' => str_repeat('word ', 102),
+    ]);
+
+    $response->assertStatus(422)->assertJsonValidationErrors('bio');
+});
+
+test('a bio of exactly 101 words is accepted', function () {
+    Storage::fake('public');
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/v1/profile', [
+        '_method' => 'PATCH',
+        'bio' => trim(str_repeat('word ', 101)),
+    ]);
+
+    $response->assertOk();
+});
+
+test('non-pdf documents are rejected', function () {
+    Storage::fake('public');
+    $user = User::factory()->cleaner()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->post('/api/v1/profile', [
+        '_method' => 'PATCH',
+        'documents' => [UploadedFile::fake()->create('notes.docx', 50, 'application/msword')],
+    ]);
+
+    $response->assertStatus(422)->assertJsonValidationErrors('documents.0');
+});
+
+test('an employer updates their own profile', function () {
+    Storage::fake('public');
+    $user = User::factory()->employer()->create();
+    Sanctum::actingAs($user);
+
+    $response = $this->post('/api/v1/profile', [
+        '_method' => 'PATCH',
+        'employer_type' => 'company',
+        'contact_person_name' => 'Maria Reyes',
+        'contact_person_contact' => 'maria@acme.test',
+        'about' => 'Commercial cleaning contractor.',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('employer_type', 'company')
+        ->assertJsonPath('contact_person_name', 'Maria Reyes');
+});
+
+test('moderators cannot update a profile', function () {
+    Sanctum::actingAs(User::factory()->moderator()->create());
+
+    $this->postJson('/api/v1/profile', ['_method' => 'PATCH', 'bio' => 'x'])
+        ->assertForbidden();
+});

--- a/tests/Feature/PublicProfileTest.php
+++ b/tests/Feature/PublicProfileTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Models\CleanerProfile;
+use App\Models\CleaningJobCategory;
+use App\Models\EmployerProfile;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('guests cannot view public profiles', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $employer = User::factory()->employer()->create();
+
+    $this->getJson("/api/v1/cleaners/{$cleaner->id}")->assertUnauthorized();
+    $this->getJson("/api/v1/employers/{$employer->id}")->assertUnauthorized();
+});
+
+test('an authenticated user can view a cleaner public profile without the email', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $profile = CleanerProfile::factory()->for($cleaner)->create(['city' => 'Cebu']);
+    $profile->cleaningJobCategories()->attach(CleaningJobCategory::factory()->create()->id);
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $response = $this->getJson("/api/v1/cleaners/{$cleaner->id}");
+
+    $response->assertOk()
+        ->assertJsonPath('user_id', $cleaner->id)
+        ->assertJsonPath('full_name', $cleaner->name)
+        ->assertJsonPath('city', 'Cebu')
+        ->assertJsonCount(1, 'cleaning_categories')
+        ->assertJsonMissingPath('email');
+});
+
+test('an authenticated user can view an employer public profile without the email', function () {
+    $employer = User::factory()->employer()->create();
+    EmployerProfile::factory()->for($employer)->create(['employer_type' => 'company']);
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $response = $this->getJson("/api/v1/employers/{$employer->id}");
+
+    $response->assertOk()
+        ->assertJsonPath('user_id', $employer->id)
+        ->assertJsonPath('employer_type', 'company')
+        ->assertJsonMissingPath('email');
+});
+
+test('the owner viewing their own public profile still sees their email', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    CleanerProfile::factory()->for($cleaner)->create();
+
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson("/api/v1/cleaners/{$cleaner->id}")
+        ->assertOk()
+        ->assertJsonPath('email', $cleaner->email);
+});
+
+test('a public profile is returned even before the profile row exists', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson("/api/v1/cleaners/{$cleaner->id}")
+        ->assertOk()
+        ->assertJsonPath('user_id', $cleaner->id)
+        ->assertJsonPath('bio', null)
+        ->assertJsonCount(0, 'cleaning_categories');
+
+    expect($cleaner->cleanerProfile()->exists())->toBeFalse();
+});
+
+test('requesting the wrong role or a missing user returns 404', function () {
+    $employer = User::factory()->employer()->create();
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson("/api/v1/cleaners/{$employer->id}")->assertNotFound();
+    $this->getJson('/api/v1/employers/999999')->assertNotFound();
+});


### PR DESCRIPTION
### Description

Introduces the full data layer and API for cleaner and employer profiles, including own-profile management (read + update), public profile views, a cleaning-category catalog, demo seeding, and a comprehensive feature-test suite.

---

#### What changed

**Database & Models**
- Added `cleaner_profiles` and `employer_profiles` tables with the matching Eloquent models (`CleanerProfile`, `EmployerProfile`).
- Added `cleaning_job_categories` table and a many-to-many pivot table (`cleaner_profile_cleaning_job_category`) linking cleaners to their skill categories.
- Attached `cleanerProfile()` and `employerProfile()` convenience relations to the `User` model.
- Added three Eloquent factories (`CleanerProfileFactory`, `EmployerProfileFactory`, `CleaningJobCategoryFactory`) and a `MaxWords` validation rule (≤ 101 words for bio fields).

**Seeders**
- `CleaningJobCategorySeeder` — seeds the canonical list of cleaning service categories.
- `DemoProfileSeeder` — seeds realistic cleaner and employer demo accounts for local development.
- Both are wired into `DatabaseSeeder`.

**API Endpoints** (`routes/api.php`)

| Method | URI | Auth | Description |
|--------|-----|------|-------------|
| `GET` | `/api/v1/categories` | public | List active cleaning categories |
| `GET` | `/api/v1/profile` | Cleaner / Employer | Read own profile (auto-creates row on first access) |
| `PATCH` | `/api/v1/profile` | Cleaner / Employer | Update own profile (multipart with method-spoofing) |
| `GET` | `/api/v1/cleaners/{id}` | Any authenticated | View a cleaner's public profile |
| `GET` | `/api/v1/employers/{id}` | Any authenticated | View an employer's public profile |

**Controllers & Resources**
- `CleaningJobCategoryController` — returns the active category list.
- `ProfileController` — role-dispatches `GET /profile` to the correct model via PHP `match`; handles `PATCH /profile` including photo upload, PDF document upload, and category sync.
- `PublicProfileController` — role-dispatched read of any user's public profile; hides email from viewers who are not the profile owner.
- `CleanerProfileResource` / `EmployerProfileResource` / `CleaningJobCategoryResource` — shape the JSON responses.
- `UpdateProfileRequest` — validates all update fields (bio word-count, photo mime/size, PDF-only documents, category IDs).

**Tests**
- `CleaningJobCategoryTest` — verifies the public category list endpoint.
- `ProfileTest` — 10 cases covering read/update for cleaner and employer, lazy profile creation on first access, bio word-count boundaries, non-PDF rejection, and moderator/admin 404 & 403 behaviour.
- `PublicProfileTest` — 6 cases covering guest 401, authenticated reads (email hidden from non-owners), owner seeing their own email, profile-less user returning empty-but-valid shape, and wrong-role/missing-user 404.

#### Rollback Guide

> Follow these steps if the branch needs to be reverted after it has been merged and deployed.

**1. Revert the code**

```bash
# On the server / in CI — revert to the previous commit on staging
git revert --no-commit <merge-commit-sha>
git commit -m "revert: feat(profiles) cleaner-employer profile system"
git push origin staging
```

Or, if you prefer a hard reset on a non-shared branch:

```bash
git checkout staging
git reset --hard <commit-sha-before-merge>
git push --force-with-lease origin staging
```

**2. Roll back the four new migrations** (in reverse dependency order)

```bash
# Remove the pivot table first (depends on both profiles and categories)
php artisan migrate:rollback --path=database/migrations/2026_07_20_114711_create_cleaner_profile_cleaning_job_category_table.php

# Then the categories table
php artisan migrate:rollback --path=database/migrations/2026_07_20_114710_create_cleaning_job_categories_table.php

# Then employer profiles (no dependents remaining)
php artisan migrate:rollback --path=database/migrations/2026_07_20_071027_create_employer_profiles_table.php

# Finally cleaner profiles
php artisan migrate:rollback --path=database/migrations/2026_07_20_071026_create_cleaner_profiles_table.php
```

> [!WARNING]
> Rolling back these migrations **permanently deletes** all data in `cleaner_profiles`, `employer_profiles`, `cleaning_job_categories`, and the pivot table. Back up the database before proceeding in production.

**3. Clear application caches**

```bash
php artisan cache:clear
php artisan config:clear
php artisan route:clear
php artisan view:clear
```

**4. Remove uploaded files (optional)**

If the storage disk was in use and you want to clean up orphaned uploads:

```bash
# Dry-run first to see what would be removed
php artisan storage:clean --dry-run 2>/dev/null || true

# Or manually remove the profile sub-directories
rm -rf storage/app/public/photos
rm -rf storage/app/public/documents
php artisan storage:link   # re-link if symlink was affected
```

**5. Verify rollback**

```bash
# Confirm the four tables are gone
php artisan tinker --execute="Schema::hasTable('cleaner_profiles') ? 'STILL EXISTS' : 'dropped ok';"
php artisan tinker --execute="Schema::hasTable('employer_profiles') ? 'STILL EXISTS' : 'dropped ok';"
php artisan tinker --execute="Schema::hasTable('cleaning_job_categories') ? 'STILL EXISTS' : 'dropped ok';"

# Confirm the new routes are gone (should 404)
curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/profile
# Expected: 401 (Sanctum auth gate) or 404 — never 200