### PR TITLE
 Feat: Add job posting, browsing, and employer-gating API

### DIFF
--- a/app/Enums/JobPostStatus.php
+++ b/app/Enums/JobPostStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum JobPostStatus: string
+{
+    case Open = 'open';
+    case Reviewing = 'reviewing';
+    case Closed = 'closed';
+    case Removed = 'removed';
+    case Completed = 'completed';
+}

--- a/app/Enums/JobPostVisibility.php
+++ b/app/Enums/JobPostVisibility.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum JobPostVisibility: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -5,12 +5,18 @@ namespace App\Http\Controllers\Api\V1;
 use App\Enums\JobPostStatus;
 use App\Enums\JobPostVisibility;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreCleaningJobPostRequest;
+use App\Http\Requests\UpdateCleaningJobPostRequest;
 use App\Http\Resources\CleaningJobPostResource;
 use App\Models\CleaningJobPost;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CleaningJobPostController extends Controller
@@ -72,6 +78,69 @@ class CleaningJobPostController extends Controller
     }
 
     /**
+     * List the authenticated employer's own job posts (every visibility and
+     * status) for their dashboard.
+     */
+    public function mine(Request $request): AnonymousResourceCollection
+    {
+        $posts = CleaningJobPost::query()
+            ->where('employer_id', $request->user()->id)
+            ->with(['employer', 'category'])
+            ->latest()
+            ->paginate(15);
+
+        return CleaningJobPostResource::collection($posts);
+    }
+
+    /**
+     * Create a job post owned by the authenticated employer.
+     */
+    public function store(StoreCleaningJobPostRequest $request): JsonResponse
+    {
+        $post = new CleaningJobPost($request->safe()->except('media'));
+        $post->employer_id = $request->user()->id;
+
+        if ($request->hasFile('media')) {
+            $post->media = $this->storeMedia($request->file('media'));
+        }
+
+        $post->save();
+        $post->load(['employer', 'category']);
+
+        return (new CleaningJobPostResource($post))->response()->setStatusCode(201);
+    }
+
+    /**
+     * Update a job post owned by the authenticated employer. Only the fields
+     * present are changed; uploaded media replaces the existing set.
+     */
+    public function update(UpdateCleaningJobPostRequest $request, CleaningJobPost $cleaningJobPost): CleaningJobPostResource
+    {
+        $cleaningJobPost->fill($request->safe()->except('media'));
+
+        if ($request->hasFile('media')) {
+            $cleaningJobPost->media = $this->storeMedia($request->file('media'));
+        }
+
+        $cleaningJobPost->save();
+        $cleaningJobPost->load(['employer', 'category']);
+
+        return new CleaningJobPostResource($cleaningJobPost);
+    }
+
+    /**
+     * Soft-delete a job post owned by the authenticated employer.
+     */
+    public function destroy(Request $request, CleaningJobPost $cleaningJobPost): JsonResponse
+    {
+        Gate::authorize('delete', $cleaningJobPost);
+
+        $cleaningJobPost->delete();
+
+        return response()->json(['message' => 'Job post deleted.']);
+    }
+
+    /**
      * Show a single job post. Guests and any user may view a published,
      * non-removed post; the owning employer may additionally view their own
      * post in any visibility/status.
@@ -91,5 +160,35 @@ class CleaningJobPostController extends Controller
         }
 
         return new CleaningJobPostResource($post);
+    }
+
+    /**
+     * Store uploaded media images on the public disk, preserving each file's
+     * original name.
+     *
+     * @param  array<int, UploadedFile>  $files
+     * @return array<int, array{name: string, path: string}>
+     */
+    protected function storeMedia(array $files): array
+    {
+        return array_map(fn (UploadedFile $file): array => [
+            'name' => $file->getClientOriginalName(),
+            'path' => $this->storeOrFail($file),
+        ], $files);
+    }
+
+    /**
+     * Store an uploaded file on the public disk, failing fast if the write
+     * does not succeed.
+     */
+    protected function storeOrFail(UploadedFile $file): string
+    {
+        $path = $file->store('job-media', 'public');
+
+        if ($path === false) {
+            throw new RuntimeException('Failed to store uploaded media.');
+        }
+
+        return $path;
     }
 }

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -7,11 +7,70 @@ use App\Enums\JobPostVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CleaningJobPostResource;
 use App\Models\CleaningJobPost;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Validation\Rule;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CleaningJobPostController extends Controller
 {
+    /**
+     * Browse published, open job posts. Guest-accessible; supports keyword
+     * search, filtering, sorting, and pagination.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $validated = $request->validate([
+            'search' => ['sometimes', 'string', 'max:255'],
+            'category_id' => ['sometimes', 'integer', Rule::exists('cleaning_job_categories', 'id')],
+            'country' => ['sometimes', 'string', 'max:255'],
+            'city' => ['sometimes', 'string', 'max:255'],
+            'schedule_date' => ['sometimes', 'date'],
+            'sort' => ['sometimes', Rule::in(['newest', 'soonest', 'high_pay', 'top_employer'])],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:50'],
+        ]);
+
+        $query = CleaningJobPost::query()
+            ->published()
+            ->open()
+            ->with(['employer', 'category'])
+            ->when(
+                isset($validated['search']),
+                fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {
+                    $term = '%'.$validated['search'].'%';
+                    $inner->where('title', 'like', $term)
+                        ->orWhere('description', 'like', $term)
+                        ->orWhereHas('employer', fn (Builder $e) => $e->where('name', 'like', $term));
+                }),
+            )
+            ->when(isset($validated['category_id']), fn (Builder $q) => $q->where('cleaning_job_category_id', $validated['category_id']))
+            ->when(isset($validated['country']), fn (Builder $q) => $q->where('country', $validated['country']))
+            ->when(isset($validated['city']), fn (Builder $q) => $q->where('city', $validated['city']))
+            ->when(isset($validated['schedule_date']), fn (Builder $q) => $q->whereDate('schedule_date', $validated['schedule_date']));
+
+        $this->applySort($query, $validated['sort'] ?? 'newest');
+
+        $posts = $query->paginate($validated['per_page'] ?? 15)->withQueryString();
+
+        return CleaningJobPostResource::collection($posts);
+    }
+
+    /**
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    protected function applySort(Builder $query, string $sort): void
+    {
+        match ($sort) {
+            'soonest' => $query->orderBy('schedule_date'),
+            'high_pay' => $query->orderByDesc('pay_amount'),
+            // top_employer sorts by employer rating once Phase 7 lands; until
+            // then there is no rating, so it falls back to newest.
+            'top_employer' => $query->orderByDesc('created_at'),
+            default => $query->orderByDesc('created_at'),
+        };
+    }
+
     /**
      * Show a single job post. Guests and any user may view a published,
      * non-removed post; the owning employer may additionally view their own

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -16,14 +16,19 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class CleaningJobPostController extends Controller
 {
     /**
-     * Browse published, open job posts. Guest-accessible; supports keyword
-     * search, filtering, sorting, and pagination.
+     * Browse published job posts. Guest-accessible; supports keyword search,
+     * filtering, sorting, and pagination. By default only `open` posts are
+     * returned; any authenticated non-cleaner (employer/moderator/admin) may
+     * filter the whole market by any status, including `removed`. Cleaners and
+     * guests cannot filter by status at all, so removed content stays off
+     * limits to them.
      */
     public function index(Request $request): AnonymousResourceCollection
     {
@@ -33,13 +38,27 @@ class CleaningJobPostController extends Controller
             'country' => ['sometimes', 'string', 'max:255'],
             'city' => ['sometimes', 'string', 'max:255'],
             'schedule_date' => ['sometimes', 'date'],
+            'status' => ['sometimes', Rule::enum(JobPostStatus::class)],
             'sort' => ['sometimes', Rule::in(['newest', 'soonest', 'high_pay', 'top_employer'])],
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:50'],
         ]);
 
+        $viewer = $request->user('sanctum');
+        $canFilterByStatus = $viewer !== null && ! $viewer->isCleaner();
+
+        if (isset($validated['status']) && ! $canFilterByStatus) {
+            throw ValidationException::withMessages([
+                'status' => 'Filtering job posts by status is not available for this account.',
+            ]);
+        }
+
         $query = CleaningJobPost::query()
             ->published()
-            ->open()
+            ->when(
+                isset($validated['status']),
+                fn (Builder $q) => $q->where('status', $validated['status']),
+                fn (Builder $q) => $q->open(),
+            )
             ->with(['employer', 'category'])
             ->when(
                 isset($validated['search']),

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CleaningJobPostResource;
+use App\Models\CleaningJobPost;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class CleaningJobPostController extends Controller
+{
+    /**
+     * Show a single job post. Guests and any user may view a published,
+     * non-removed post; the owning employer may additionally view their own
+     * post in any visibility/status.
+     */
+    public function show(Request $request, int $id): CleaningJobPostResource
+    {
+        $post = CleaningJobPost::with(['employer', 'category'])->findOrFail($id);
+
+        $viewer = $request->user('sanctum');
+        $isOwner = $viewer !== null && $viewer->id === $post->employer_id;
+
+        $isPubliclyVisible = $post->visibility === JobPostVisibility::Published
+            && $post->status !== JobPostStatus::Removed;
+
+        if (! $isOwner && ! $isPubliclyVisible) {
+            throw new NotFoundHttpException;
+        }
+
+        return new CleaningJobPostResource($post);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -106,17 +106,40 @@ class CleaningJobPostController extends Controller
 
     /**
      * List the authenticated employer's own job posts (every visibility and
-     * status) for their dashboard.
+     * status) for their dashboard. Supports keyword search, status and schedule
+     * filtering, and sorting — all scoped to the employer's own posts, so any
+     * status (including `removed`) is filterable here.
      */
     public function mine(Request $request): AnonymousResourceCollection
     {
-        $posts = CleaningJobPost::query()
+        $validated = $request->validate([
+            'search' => ['sometimes', 'string', 'max:255'],
+            'status' => ['sometimes', Rule::enum(JobPostStatus::class)],
+            'schedule_date' => ['sometimes', 'date'],
+            'sort' => ['sometimes', Rule::in(['newest', 'oldest', 'soonest'])],
+        ]);
+
+        $query = CleaningJobPost::query()
             ->where('employer_id', $request->user()->id)
             ->with(['employer', 'category'])
-            ->latest()
-            ->paginate(15);
+            ->when(
+                isset($validated['search']),
+                fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {
+                    $term = '%'.$validated['search'].'%';
+                    $inner->where('title', 'like', $term)
+                        ->orWhere('description', 'like', $term);
+                }),
+            )
+            ->when(isset($validated['status']), fn (Builder $q) => $q->where('status', $validated['status']))
+            ->when(isset($validated['schedule_date']), fn (Builder $q) => $q->whereDate('schedule_date', $validated['schedule_date']));
 
-        return CleaningJobPostResource::collection($posts);
+        match ($validated['sort'] ?? 'newest') {
+            'oldest' => $query->orderBy('created_at'),
+            'soonest' => $query->orderBy('schedule_date'),
+            default => $query->orderByDesc('created_at'),
+        };
+
+        return CleaningJobPostResource::collection($query->paginate(15));
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -41,7 +41,7 @@ class CleaningJobPostController extends Controller
             'city' => ['sometimes', 'string', 'max:255'],
             'schedule_date' => ['sometimes', 'date'],
             'status' => ['sometimes', Rule::enum(JobPostStatus::class)],
-            'sort' => ['sometimes', Rule::in(['newest', 'soonest', 'high_pay', 'top_employer'])],
+            'sort' => ['sometimes', Rule::in(['newest', 'soonest', 'top_employer'])],
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:50'],
         ]);
 
@@ -90,7 +90,6 @@ class CleaningJobPostController extends Controller
     {
         match ($sort) {
             'soonest' => $query->orderBy('schedule_date'),
-            'high_pay' => $query->orderByDesc('pay_amount'),
             // top_employer sorts by employer rating once Phase 7 lands; until
             // then there is no rating, so it falls back to newest.
             'top_employer' => $query->orderByDesc('created_at'),

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Enums\JobPostStatus;
 use App\Enums\JobPostVisibility;
+use App\Enums\UserRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreCleaningJobPostRequest;
 use App\Http\Requests\UpdateCleaningJobPostRequest;
 use App\Http\Resources\CleaningJobPostResource;
 use App\Models\CleaningJobPost;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -104,6 +106,27 @@ class CleaningJobPostController extends Controller
     {
         $posts = CleaningJobPost::query()
             ->where('employer_id', $request->user()->id)
+            ->with(['employer', 'category'])
+            ->latest()
+            ->paginate(15);
+
+        return CleaningJobPostResource::collection($posts);
+    }
+
+    /**
+     * List a given employer's public job posts for their profile page: every
+     * published post across open/reviewing/closed/completed. Drafts (not yet
+     * public) and removed (hidden) posts are excluded. Any authenticated user
+     * may view this.
+     */
+    public function forEmployer(int $id): AnonymousResourceCollection
+    {
+        $employer = User::where('role', UserRole::Employer)->findOrFail($id);
+
+        $posts = CleaningJobPost::query()
+            ->where('employer_id', $employer->id)
+            ->published()
+            ->where('status', '!=', JobPostStatus::Removed->value)
             ->with(['employer', 'category'])
             ->latest()
             ->paginate(15);

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -54,12 +54,19 @@ class CleaningJobPostController extends Controller
             ]);
         }
 
+        // A searching cleaner sees published posts of any status except removed,
+        // so a keyword can surface reviewing/closed/completed posts; the plain
+        // feed and guests stay open-only.
+        $searchingCleaner = isset($validated['search'])
+            && $viewer !== null
+            && $viewer->isCleaner();
+
         $query = CleaningJobPost::query()
             ->published()
             ->when(
                 isset($validated['status']),
                 fn (Builder $q) => $q->where('status', $validated['status']),
-                fn (Builder $q) => $q->open(),
+                fn (Builder $q) => $searchingCleaner ? $q->notRemoved() : $q->open(),
             )
             ->with(['employer', 'category'])
             ->when(

--- a/app/Http/Requests/StoreCleaningJobPostRequest.php
+++ b/app/Http/Requests/StoreCleaningJobPostRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\JobPostVisibility;
+use App\Models\CleaningJobPost;
+use App\Rules\MaxWords;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class StoreCleaningJobPostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', CleaningJobPost::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', new MaxWords(101)],
+            'cleaning_job_category_id' => ['required', 'integer', Rule::exists('cleaning_job_categories', 'id')->where('is_active', true)],
+            'description' => ['required', 'string'],
+            'requirements' => ['nullable', 'string', 'max:5000'],
+            'qualifications' => ['nullable', 'string', 'max:5000'],
+            'country' => ['required', 'string', 'max:255'],
+            'city' => ['required', 'string', 'max:255'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'schedule_date' => ['required', 'date', 'after_or_equal:today'],
+            'start_time' => ['nullable', 'date_format:H:i'],
+            'end_time' => ['nullable', 'date_format:H:i'],
+            'cleaners_needed' => ['nullable', 'integer', 'min:1', 'max:65535'],
+            'application_deadline' => ['nullable', 'date', 'before_or_equal:schedule_date'],
+            'visibility' => ['sometimes', Rule::enum(JobPostVisibility::class)],
+            'pay_amount' => ['nullable', 'numeric', 'min:0', 'max:99999999.99'],
+            'pay_currency' => ['nullable', 'string', 'size:3'],
+            'media' => ['nullable', 'array', 'max:10'],
+            'media.*' => ['image', File::image()->max(5 * 1024)],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCleaningJobPostRequest.php
+++ b/app/Http/Requests/UpdateCleaningJobPostRequest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Models\CleaningJobPost;
+use App\Rules\MaxWords;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class UpdateCleaningJobPostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $post = $this->route('cleaningJobPost');
+
+        return $post instanceof CleaningJobPost && $this->user()->can('update', $post);
+    }
+
+    /**
+     * A draft post's content is fully editable but its status is fixed at
+     * `open` until it is published. Once published, the content is locked and
+     * the only editable field is `status`, which moves forward only
+     * (open → reviewing → closed → completed) and can never be set to
+     * `removed` (a moderator/admin hide). A completed post is terminal.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $post = $this->route('cleaningJobPost');
+
+        if ($post instanceof CleaningJobPost && $post->visibility === JobPostVisibility::Published) {
+            return $this->publishedRules($post);
+        }
+
+        return $this->draftRules();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function draftRules(): array
+    {
+        return [
+            'title' => ['sometimes', 'string', new MaxWords(101)],
+            'cleaning_job_category_id' => ['sometimes', 'integer', Rule::exists('cleaning_job_categories', 'id')->where('is_active', true)],
+            'description' => ['sometimes', 'string'],
+            'requirements' => ['sometimes', 'nullable', 'string', 'max:5000'],
+            'qualifications' => ['sometimes', 'nullable', 'string', 'max:5000'],
+            'country' => ['sometimes', 'string', 'max:255'],
+            'city' => ['sometimes', 'string', 'max:255'],
+            'address' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'schedule_date' => ['sometimes', 'date', 'after_or_equal:today'],
+            'start_time' => ['sometimes', 'nullable', 'date_format:H:i'],
+            'end_time' => ['sometimes', 'nullable', 'date_format:H:i'],
+            'cleaners_needed' => ['sometimes', 'integer', 'min:1', 'max:65535'],
+            'application_deadline' => ['sometimes', 'nullable', 'date', 'before_or_equal:schedule_date'],
+            'visibility' => ['sometimes', Rule::enum(JobPostVisibility::class)],
+            'status' => ['prohibited'],
+            'pay_amount' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:99999999.99'],
+            'pay_currency' => ['sometimes', 'nullable', 'string', 'size:3'],
+            'media' => ['sometimes', 'nullable', 'array', 'max:10'],
+            'media.*' => ['image', File::image()->max(5 * 1024)],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function publishedRules(CleaningJobPost $post): array
+    {
+        $locked = ['prohibited'];
+
+        return [
+            'status' => ['sometimes', Rule::enum(JobPostStatus::class)->except(JobPostStatus::Removed), $this->forwardOnlyStatus($post)],
+            'title' => $locked,
+            'cleaning_job_category_id' => $locked,
+            'description' => $locked,
+            'requirements' => $locked,
+            'qualifications' => $locked,
+            'country' => $locked,
+            'city' => $locked,
+            'address' => $locked,
+            'schedule_date' => $locked,
+            'start_time' => $locked,
+            'end_time' => $locked,
+            'cleaners_needed' => $locked,
+            'application_deadline' => $locked,
+            'visibility' => $locked,
+            'pay_amount' => $locked,
+            'pay_currency' => $locked,
+            'media' => $locked,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'prohibited' => 'A published job post is locked; only its status can be changed.',
+            'status.prohibited' => "A job post's status cannot be changed until it is published.",
+        ];
+    }
+
+    /**
+     * Enforce the forward-only status flow: a post may only advance to a later
+     * step (open → reviewing → closed → completed), never move backward, and a
+     * completed post is terminal.
+     */
+    protected function forwardOnlyStatus(CleaningJobPost $post): Closure
+    {
+        $order = [
+            JobPostStatus::Open->value => 0,
+            JobPostStatus::Reviewing->value => 1,
+            JobPostStatus::Closed->value => 2,
+            JobPostStatus::Completed->value => 3,
+        ];
+
+        return function (string $attribute, mixed $value, Closure $fail) use ($order, $post): void {
+            $current = $post->status->value;
+
+            if (! array_key_exists($current, $order)) {
+                $fail("This job post's status can no longer be changed.");
+
+                return;
+            }
+
+            if (is_string($value) && array_key_exists($value, $order) && $order[$value] < $order[$current]) {
+                $fail('A job post status can only move forward: open → reviewing → closed → completed.');
+            }
+        };
+    }
+}

--- a/app/Http/Resources/CleaningJobPostResource.php
+++ b/app/Http/Resources/CleaningJobPostResource.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\CleaningJobPost;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @mixin CleaningJobPost
+ */
+class CleaningJobPostResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $viewer = $request->user('sanctum');
+        $isOwner = $viewer !== null && $viewer->id === $this->employer_id;
+
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'requirements' => $this->requirements,
+            'qualifications' => $this->qualifications,
+            'category' => [
+                'id' => $this->category->id,
+                'name' => $this->category->name,
+            ],
+            'employer' => [
+                'id' => $this->employer->id,
+                'name' => $this->employer->name,
+                'rating_average' => null,
+                'rating_count' => 0,
+            ],
+            'country' => $this->country,
+            'city' => $this->city,
+            'address' => $this->address,
+            'schedule_date' => $this->schedule_date->toDateString(),
+            'start_time' => $this->formatTime($this->start_time),
+            'end_time' => $this->formatTime($this->end_time),
+            'cleaners_needed' => $this->cleaners_needed,
+            'application_deadline' => $this->application_deadline?->toDateString(),
+            'visibility' => $this->visibility->value,
+            'status' => $this->status->value,
+            'pay_amount' => $this->pay_amount === null ? null : (float) $this->pay_amount,
+            'pay_currency' => $this->pay_currency,
+            'media' => $this->mapMedia(),
+            'applications_count' => $this->when($isOwner, 0),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    protected function formatTime(?string $time): ?string
+    {
+        return $time === null ? null : substr($time, 0, 5);
+    }
+
+    /**
+     * @return array<int, array{name: string, url: string}>
+     */
+    protected function mapMedia(): array
+    {
+        return collect($this->media ?? [])
+            ->map(fn (array $item): array => [
+                'name' => $item['name'],
+                'url' => Storage::disk('public')->url($item['path']),
+            ])
+            ->all();
+    }
+}

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -6,6 +6,7 @@ use App\Enums\JobPostStatus;
 use App\Enums\JobPostVisibility;
 use Database\Factories\CleaningJobPostFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -94,5 +95,21 @@ class CleaningJobPost extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(CleaningJobCategory::class, 'cleaning_job_category_id');
+    }
+
+    /**
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    public function scopePublished(Builder $query): void
+    {
+        $query->where('visibility', JobPostVisibility::Published);
+    }
+
+    /**
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    public function scopeOpen(Builder $query): void
+    {
+        $query->where('status', JobPostStatus::Open);
     }
 }

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -124,4 +124,12 @@ class CleaningJobPost extends Model
     {
         $query->where('status', JobPostStatus::Open);
     }
+
+    /**
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    public function scopeNotRemoved(Builder $query): void
+    {
+        $query->where('status', '!=', JobPostStatus::Removed);
+    }
 }

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -66,6 +66,18 @@ class CleaningJobPost extends Model
     use HasFactory, SoftDeletes;
 
     /**
+     * Mirror the database column defaults so a new instance has correct values
+     * before it is saved.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'visibility' => 'draft',
+        'status' => 'open',
+        'cleaners_needed' => 1,
+    ];
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use Database\Factories\CleaningJobPostFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $employer_id
+ * @property int $cleaning_job_category_id
+ * @property string $title
+ * @property string $description
+ * @property string|null $requirements
+ * @property string|null $qualifications
+ * @property string $country
+ * @property string $city
+ * @property string|null $address
+ * @property Carbon $schedule_date
+ * @property string|null $start_time
+ * @property string|null $end_time
+ * @property int $cleaners_needed
+ * @property Carbon|null $application_deadline
+ * @property JobPostVisibility $visibility
+ * @property JobPostStatus $status
+ * @property string|null $pay_amount
+ * @property string|null $pay_currency
+ * @property array<int, array{name: string, path: string}>|null $media
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read User $employer
+ * @property-read CleaningJobCategory $category
+ */
+#[Fillable([
+    'cleaning_job_category_id',
+    'title',
+    'description',
+    'requirements',
+    'qualifications',
+    'country',
+    'city',
+    'address',
+    'schedule_date',
+    'start_time',
+    'end_time',
+    'cleaners_needed',
+    'application_deadline',
+    'visibility',
+    'status',
+    'pay_amount',
+    'pay_currency',
+    'media',
+])]
+class CleaningJobPost extends Model
+{
+    /** @use HasFactory<CleaningJobPostFactory> */
+    use HasFactory, SoftDeletes;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'schedule_date' => 'date',
+            'application_deadline' => 'date',
+            'cleaners_needed' => 'integer',
+            'visibility' => JobPostVisibility::class,
+            'status' => JobPostStatus::class,
+            'pay_amount' => 'decimal:2',
+            'media' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function employer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'employer_id');
+    }
+
+    /**
+     * @return BelongsTo<CleaningJobCategory, $this>
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(CleaningJobCategory::class, 'cleaning_job_category_id');
+    }
+}

--- a/app/Policies/CleaningJobPostPolicy.php
+++ b/app/Policies/CleaningJobPostPolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CleaningJobPost;
+use App\Models\User;
+
+/**
+ * The admin bypasses every check via the Gate::before hook in
+ * AppServiceProvider. Job posts are authored and managed only by the employer
+ * who owns them.
+ */
+class CleaningJobPostPolicy
+{
+    public function create(User $user): bool
+    {
+        return $user->isEmployer();
+    }
+
+    public function update(User $user, CleaningJobPost $cleaningJobPost): bool
+    {
+        return $user->isEmployer() && $user->id === $cleaningJobPost->employer_id;
+    }
+
+    /**
+     * Job posts are deleted by an admin only (through the Gate::before
+     * superuser hook). Employers cannot delete their own posts — deny everyone
+     * here so the admin bypass is the sole path.
+     */
+    public function delete(User $user, CleaningJobPost $cleaningJobPost): bool
+    {
+        return false;
+    }
+}

--- a/database/factories/CleaningJobPostFactory.php
+++ b/database/factories/CleaningJobPostFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Enums\UserRole;
+use App\Models\CleaningJobCategory;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CleaningJobPost>
+ */
+class CleaningJobPostFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'employer_id' => User::factory()->state(['role' => UserRole::Employer]),
+            'cleaning_job_category_id' => CleaningJobCategory::factory(),
+            'title' => fake()->randomElement(['Residential Deep Cleaning', 'Office Nightly Clean', 'Hotel Housekeeping', 'Post-Event Cleanup']).' Needed',
+            'description' => fake()->paragraph(),
+            'requirements' => fake()->optional()->sentence(),
+            'qualifications' => fake()->optional()->sentence(),
+            'country' => fake()->country(),
+            'city' => fake()->city(),
+            'address' => fake()->optional()->streetAddress(),
+            'schedule_date' => fake()->dateTimeBetween('+3 days', '+2 months')->format('Y-m-d'),
+            'start_time' => '09:00',
+            'end_time' => '13:00',
+            'cleaners_needed' => fake()->numberBetween(1, 5),
+            'application_deadline' => fake()->boolean(70) ? fake()->dateTimeBetween('now', '+2 days')->format('Y-m-d') : null,
+            'visibility' => JobPostVisibility::Published,
+            'status' => JobPostStatus::Open,
+            'pay_amount' => fake()->randomFloat(2, 15, 200),
+            'pay_currency' => fake()->randomElement(['USD', 'EUR', 'PHP']),
+            'media' => [],
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => ['visibility' => JobPostVisibility::Draft]);
+    }
+
+    public function status(JobPostStatus $status): static
+    {
+        return $this->state(fn (array $attributes) => ['status' => $status]);
+    }
+}

--- a/database/migrations/2026_07_22_132355_create_cleaning_job_posts_table.php
+++ b/database/migrations/2026_07_22_132355_create_cleaning_job_posts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cleaning_job_posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employer_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('cleaning_job_category_id')->constrained()->restrictOnDelete();
+            $table->string('title');
+            $table->text('description');
+            $table->text('requirements')->nullable();
+            $table->text('qualifications')->nullable();
+            $table->string('country')->index();
+            $table->string('city')->index();
+            $table->string('address')->nullable();
+            $table->date('schedule_date')->index();
+            $table->time('start_time')->nullable();
+            $table->time('end_time')->nullable();
+            $table->unsignedSmallInteger('cleaners_needed')->default(1);
+            $table->date('application_deadline')->nullable();
+            $table->string('visibility')->default('draft')->index();
+            $table->string('status')->default('open')->index();
+            $table->decimal('pay_amount', 10, 2)->nullable()->index();
+            $table->char('pay_currency', 3)->nullable();
+            $table->json('media')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cleaning_job_posts');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,7 +20,10 @@ class DatabaseSeeder extends Seeder
         ]);
 
         if (! app()->environment('production')) {
-            $this->call(DemoProfileSeeder::class);
+            $this->call([
+                DemoProfileSeeder::class,
+                DemoJobPostSeeder::class,
+            ]);
         }
     }
 }

--- a/database/seeders/DemoJobPostSeeder.php
+++ b/database/seeders/DemoJobPostSeeder.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Models\CleaningJobCategory;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+/**
+ * Dev-only demo job posts spanning categories, visibilities, statuses, pay,
+ * and media so the frontend can develop the browse/filter/sort UI and the
+ * employer dashboard against real records. Idempotent (keyed on employer +
+ * title); depends on DemoProfileSeeder having created the demo employers.
+ */
+class DemoJobPostSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $employers = User::whereIn('email', ['employer1@demo.test', 'employer2@demo.test', 'employer3@demo.test'])
+            ->get()
+            ->keyBy('email');
+
+        if ($employers->isEmpty()) {
+            return;
+        }
+
+        $categories = CleaningJobCategory::pluck('id', 'slug');
+
+        $posts = [
+            [
+                'email' => 'employer1@demo.test', 'category' => 'office',
+                'title' => 'Office Nightly Cleaning', 'country' => 'Philippines', 'city' => 'Manila',
+                'visibility' => JobPostVisibility::Published, 'status' => JobPostStatus::Open,
+                'pay_amount' => 22.50, 'pay_currency' => 'USD', 'days' => 10, 'media' => true,
+            ],
+            [
+                'email' => 'employer1@demo.test', 'category' => 'public-space',
+                'title' => 'Mall Deep Clean Contract', 'country' => 'Philippines', 'city' => 'Makati',
+                'visibility' => JobPostVisibility::Published, 'status' => JobPostStatus::Closed,
+                'pay_amount' => 1800.00, 'pay_currency' => 'USD', 'days' => 4, 'media' => false,
+            ],
+            [
+                'email' => 'employer2@demo.test', 'category' => 'hotel',
+                'title' => 'Hotel Housekeeping Team', 'country' => 'Germany', 'city' => 'Berlin',
+                'visibility' => JobPostVisibility::Published, 'status' => JobPostStatus::Open,
+                'pay_amount' => 140.00, 'pay_currency' => 'EUR', 'days' => 21, 'media' => true,
+            ],
+            [
+                'email' => 'employer2@demo.test', 'category' => 'hotel',
+                'title' => 'Seasonal Room Turnover', 'country' => 'Germany', 'city' => 'Munich',
+                'visibility' => JobPostVisibility::Published, 'status' => JobPostStatus::Completed,
+                'pay_amount' => 130.00, 'pay_currency' => 'EUR', 'days' => 2, 'media' => false,
+            ],
+            [
+                'email' => 'employer3@demo.test', 'category' => 'residential',
+                'title' => 'Home Weekly Cleaning', 'country' => 'Philippines', 'city' => 'Davao City',
+                'visibility' => JobPostVisibility::Published, 'status' => JobPostStatus::Open,
+                'pay_amount' => 18.00, 'pay_currency' => 'USD', 'days' => 7, 'media' => false,
+            ],
+            [
+                'email' => 'employer3@demo.test', 'category' => 'residential',
+                'title' => 'Move-out Deep Clean', 'country' => 'Philippines', 'city' => 'Davao City',
+                'visibility' => JobPostVisibility::Draft, 'status' => JobPostStatus::Open,
+                'pay_amount' => 90.00, 'pay_currency' => 'USD', 'days' => 14, 'media' => false,
+            ],
+        ];
+
+        foreach ($posts as $data) {
+            $employer = $employers->get($data['email']);
+            $categoryId = $categories->get($data['category']);
+
+            if ($employer === null || $categoryId === null) {
+                continue;
+            }
+
+            $post = CleaningJobPost::firstOrCreate(
+                ['employer_id' => $employer->id, 'title' => $data['title']],
+                [
+                    'cleaning_job_category_id' => $categoryId,
+                    'description' => 'Demo listing for '.$data['title'].'. Reliable, detail-oriented cleaning help needed.',
+                    'country' => $data['country'],
+                    'city' => $data['city'],
+                    'schedule_date' => Carbon::now()->addDays($data['days'])->toDateString(),
+                    'start_time' => '09:00',
+                    'end_time' => '13:00',
+                    'cleaners_needed' => 2,
+                    'visibility' => $data['visibility'],
+                    'status' => $data['status'],
+                    'pay_amount' => $data['pay_amount'],
+                    'pay_currency' => $data['pay_currency'],
+                ],
+            );
+
+            if ($post->wasRecentlyCreated && $data['media']) {
+                $post->media = [$this->placeholderImage()];
+                $post->save();
+            }
+        }
+    }
+
+    /**
+     * Generate and store a small placeholder image so demo media resolves to a
+     * real file on the public disk rather than a broken link.
+     *
+     * @return array{name: string, path: string}
+     */
+    protected function placeholderImage(): array
+    {
+        $image = imagecreatetruecolor(400, 300);
+
+        if ($image === false) {
+            throw new RuntimeException('Unable to create a placeholder image.');
+        }
+
+        $color = imagecolorallocate($image, random_int(90, 200), random_int(90, 200), random_int(90, 200));
+
+        if ($color === false) {
+            throw new RuntimeException('Unable to allocate a placeholder color.');
+        }
+
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+        $contents = (string) ob_get_clean();
+        imagedestroy($image);
+
+        $path = 'job-media/'.Str::random(24).'.png';
+        Storage::disk('public')->put($path, $contents);
+
+        return ['name' => 'site-photo.png', 'path' => $path];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ Route::prefix('v1')->group(function (): void {
 
     Route::get('cleaning-job-categories', [CleaningJobCategoryController::class, 'index']);
 
+    Route::get('cleaning-job-posts', [CleaningJobPostController::class, 'index']);
     Route::get('cleaning-job-posts/{id}', [CleaningJobPostController::class, 'show'])
         ->whereNumber('id');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,8 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('cleaners/{id}', [PublicProfileController::class, 'cleaner']);
         Route::get('employers/{id}', [PublicProfileController::class, 'employer']);
+        Route::get('employers/{id}/cleaning-job-posts', [CleaningJobPostController::class, 'forEmployer'])
+            ->whereNumber('id');
 
         Route::get('cleaning-job-posts/mine', [CleaningJobPostController::class, 'mine']);
         Route::post('cleaning-job-posts', [CleaningJobPostController::class, 'store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
+use App\Http\Controllers\Api\V1\CleaningJobPostController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\PublicProfileController;
 use Illuminate\Http\Request;
@@ -29,6 +30,9 @@ Route::prefix('v1')->group(function (): void {
     });
 
     Route::get('cleaning-job-categories', [CleaningJobCategoryController::class, 'index']);
+
+    Route::get('cleaning-job-posts/{id}', [CleaningJobPostController::class, 'show'])
+        ->whereNumber('id');
 
     Route::middleware('auth:sanctum')->group(function (): void {
         Route::get('profile', [ProfileController::class, 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,6 +41,13 @@ Route::prefix('v1')->group(function (): void {
 
         Route::get('cleaners/{id}', [PublicProfileController::class, 'cleaner']);
         Route::get('employers/{id}', [PublicProfileController::class, 'employer']);
+
+        Route::get('cleaning-job-posts/mine', [CleaningJobPostController::class, 'mine']);
+        Route::post('cleaning-job-posts', [CleaningJobPostController::class, 'store']);
+        Route::patch('cleaning-job-posts/{cleaningJobPost}', [CleaningJobPostController::class, 'update'])
+            ->whereNumber('cleaningJobPost');
+        Route::delete('cleaning-job-posts/{cleaningJobPost}', [CleaningJobPostController::class, 'destroy'])
+            ->whereNumber('cleaningJobPost');
     });
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());

--- a/tests/Feature/CleaningJobPostBrowseTest.php
+++ b/tests/Feature/CleaningJobPostBrowseTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Enums\JobPostStatus;
+use App\Models\CleaningJobCategory;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+
+test('guests can browse published open posts in a paginated envelope', function () {
+    CleaningJobPost::factory()->count(3)->create();
+    CleaningJobPost::factory()->draft()->create();
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+
+    $response = $this->getJson('/api/v1/cleaning-job-posts');
+
+    $response->assertOk()
+        ->assertJsonCount(3, 'data')
+        ->assertJsonStructure([
+            'data' => [['id', 'title', 'category' => ['id', 'name'], 'employer' => ['id', 'name']]],
+            'links' => ['first', 'last', 'prev', 'next'],
+            'meta' => ['current_page', 'last_page', 'per_page', 'total'],
+        ]);
+});
+
+test('search matches title, description, and employer name', function () {
+    $employer = User::factory()->employer()->create(['name' => 'Sparkle Cleaning Co']);
+    CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'title' => 'Generic job']);
+    CleaningJobPost::factory()->create(['title' => 'Hotel Housekeeping Needed', 'description' => 'x']);
+    CleaningJobPost::factory()->create(['title' => 'Unrelated', 'description' => 'x']);
+
+    $this->getJson('/api/v1/cleaning-job-posts?search=Sparkle')
+        ->assertOk()->assertJsonCount(1, 'data');
+
+    $this->getJson('/api/v1/cleaning-job-posts?search=Housekeeping')
+        ->assertOk()->assertJsonCount(1, 'data');
+});
+
+test('posts can be filtered by category, country, and city', function () {
+    $category = CleaningJobCategory::factory()->create();
+    CleaningJobPost::factory()->create(['cleaning_job_category_id' => $category->id, 'country' => 'Italy', 'city' => 'Rome']);
+    CleaningJobPost::factory()->create(['country' => 'Japan', 'city' => 'Tokyo']);
+
+    $this->getJson("/api/v1/cleaning-job-posts?category_id={$category->id}")
+        ->assertOk()->assertJsonCount(1, 'data');
+
+    $this->getJson('/api/v1/cleaning-job-posts?country=Japan')
+        ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.city', 'Tokyo');
+});
+
+test('posts can be sorted by soonest schedule and highest pay', function () {
+    $soon = CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(2)->toDateString(), 'pay_amount' => 10]);
+    $later = CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(30)->toDateString(), 'pay_amount' => 500]);
+
+    $this->getJson('/api/v1/cleaning-job-posts?sort=soonest')
+        ->assertOk()->assertJsonPath('data.0.id', $soon->id);
+
+    $this->getJson('/api/v1/cleaning-job-posts?sort=high_pay')
+        ->assertOk()->assertJsonPath('data.0.id', $later->id);
+});
+
+test('per_page controls pagination size', function () {
+    CleaningJobPost::factory()->count(5)->create();
+
+    $this->getJson('/api/v1/cleaning-job-posts?per_page=2')
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('meta.per_page', 2)
+        ->assertJsonPath('meta.total', 5);
+});
+
+test('an invalid sort value is rejected', function () {
+    $this->getJson('/api/v1/cleaning-job-posts?sort=cheapest')
+        ->assertStatus(422)->assertJsonValidationErrors('sort');
+});

--- a/tests/Feature/CleaningJobPostBrowseTest.php
+++ b/tests/Feature/CleaningJobPostBrowseTest.php
@@ -4,6 +4,7 @@ use App\Enums\JobPostStatus;
 use App\Models\CleaningJobCategory;
 use App\Models\CleaningJobPost;
 use App\Models\User;
+use Laravel\Sanctum\Sanctum;
 
 test('guests can browse published open posts in a paginated envelope', function () {
     CleaningJobPost::factory()->count(3)->create();
@@ -70,4 +71,73 @@ test('per_page controls pagination size', function () {
 test('an invalid sort value is rejected', function () {
     $this->getJson('/api/v1/cleaning-job-posts?sort=cheapest')
         ->assertStatus(422)->assertJsonValidationErrors('sort');
+});
+
+test('an authenticated employer can filter the market by other statuses', function () {
+    CleaningJobPost::factory()->create(); // open
+    CleaningJobPost::factory()->status(JobPostStatus::Completed)->create();
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=completed')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'completed');
+});
+
+test('a moderator can also filter the market by status', function () {
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+
+    Sanctum::actingAs(User::factory()->moderator()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=closed')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'closed');
+});
+
+test('a guest cannot use the status filter', function () {
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=closed')
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('a cleaner cannot use the status filter on browse', function () {
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=closed')
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('a non-cleaner can filter by removed status', function () {
+    CleaningJobPost::factory()->status(JobPostStatus::Removed)->create();
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=removed')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'removed');
+});
+
+test('a cleaner cannot see removed posts through the filter', function () {
+    CleaningJobPost::factory()->status(JobPostStatus::Removed)->create();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts?status=removed')
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('everyone still sees only open posts by default', function () {
+    CleaningJobPost::factory()->create(); // open
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'open');
 });

--- a/tests/Feature/CleaningJobPostBrowseTest.php
+++ b/tests/Feature/CleaningJobPostBrowseTest.php
@@ -47,15 +47,12 @@ test('posts can be filtered by category, country, and city', function () {
         ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.city', 'Tokyo');
 });
 
-test('posts can be sorted by soonest schedule and highest pay', function () {
-    $soon = CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(2)->toDateString(), 'pay_amount' => 10]);
-    $later = CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(30)->toDateString(), 'pay_amount' => 500]);
+test('posts can be sorted by soonest schedule', function () {
+    $soon = CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(2)->toDateString()]);
+    CleaningJobPost::factory()->create(['schedule_date' => now()->addDays(30)->toDateString()]);
 
     $this->getJson('/api/v1/cleaning-job-posts?sort=soonest')
         ->assertOk()->assertJsonPath('data.0.id', $soon->id);
-
-    $this->getJson('/api/v1/cleaning-job-posts?sort=high_pay')
-        ->assertOk()->assertJsonPath('data.0.id', $later->id);
 });
 
 test('per_page controls pagination size', function () {

--- a/tests/Feature/CleaningJobPostBrowseTest.php
+++ b/tests/Feature/CleaningJobPostBrowseTest.php
@@ -138,3 +138,42 @@ test('everyone still sees only open posts by default', function () {
         ->assertJsonCount(1, 'data')
         ->assertJsonPath('data.0.status', 'open');
 });
+
+test('a searching cleaner finds published posts of any non-removed status', function () {
+    $reviewing = CleaningJobPost::factory()->status(JobPostStatus::Reviewing)->create(['title' => 'Warehouse Deep Clean']);
+    $closed = CleaningJobPost::factory()->status(JobPostStatus::Closed)->create(['title' => 'Warehouse Night Shift']);
+    $completed = CleaningJobPost::factory()->status(JobPostStatus::Completed)->create(['title' => 'Warehouse Restock Clean']);
+    $removed = CleaningJobPost::factory()->status(JobPostStatus::Removed)->create(['title' => 'Warehouse Flagged Post']);
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $response = $this->getJson('/api/v1/cleaning-job-posts?search=Warehouse')
+        ->assertOk()
+        ->assertJsonCount(3, 'data');
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($reviewing->id, $closed->id, $completed->id)
+        ->not->toContain($removed->id);
+});
+
+test('a guest searching does not see non-open posts', function () {
+    CleaningJobPost::factory()->status(JobPostStatus::Reviewing)->create(['title' => 'Warehouse Deep Clean']);
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create(['title' => 'Warehouse Night Shift']);
+
+    $this->getJson('/api/v1/cleaning-job-posts?search=Warehouse')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+test('a cleaner without a search param still sees only open posts', function () {
+    CleaningJobPost::factory()->create(); // open
+    CleaningJobPost::factory()->status(JobPostStatus::Reviewing)->create();
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'open');
+});

--- a/tests/Feature/CleaningJobPostManageTest.php
+++ b/tests/Feature/CleaningJobPostManageTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\JobPostStatus;
 use App\Models\CleaningJobCategory;
 use App\Models\CleaningJobPost;
 use App\Models\User;
@@ -114,4 +115,68 @@ test('an employer lists only their own posts via mine', function () {
 
 test('a guest cannot access the mine listing', function () {
     $this->getJson('/api/v1/cleaning-job-posts/mine')->assertUnauthorized();
+});
+
+test('the mine listing can be searched by title and description', function () {
+    $employer = User::factory()->employer()->create();
+    $match = CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'title' => 'Warehouse Deep Clean']);
+    CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'title' => 'Office Reception', 'description' => 'x']);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?search=Warehouse')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $match->id);
+});
+
+test('the mine listing can be filtered by any status including removed', function () {
+    $employer = User::factory()->employer()->create();
+    CleaningJobPost::factory()->create(['employer_id' => $employer->id]); // open
+    $removed = CleaningJobPost::factory()->status(JobPostStatus::Removed)->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?status=removed')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $removed->id);
+});
+
+test('the mine listing can be filtered by schedule date', function () {
+    $employer = User::factory()->employer()->create();
+    $date = now()->addDays(10)->toDateString();
+    $match = CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'schedule_date' => $date]);
+    CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'schedule_date' => now()->addDays(20)->toDateString()]);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/mine?schedule_date={$date}")
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $match->id);
+});
+
+test('the mine listing can be sorted oldest and soonest', function () {
+    $employer = User::factory()->employer()->create();
+    $old = CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'created_at' => now()->subDays(5), 'schedule_date' => now()->addDays(30)->toDateString()]);
+    $new = CleaningJobPost::factory()->create(['employer_id' => $employer->id, 'created_at' => now(), 'schedule_date' => now()->addDays(2)->toDateString()]);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?sort=oldest')
+        ->assertOk()->assertJsonPath('data.0.id', $old->id);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?sort=soonest')
+        ->assertOk()->assertJsonPath('data.0.id', $new->id);
+});
+
+test('the mine listing rejects an invalid sort or status value', function () {
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?sort=top_employer')
+        ->assertStatus(422)->assertJsonValidationErrors('sort');
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine?status=bogus')
+        ->assertStatus(422)->assertJsonValidationErrors('status');
 });

--- a/tests/Feature/CleaningJobPostManageTest.php
+++ b/tests/Feature/CleaningJobPostManageTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Models\CleaningJobCategory;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+function validJobPostPayload(array $overrides = []): array
+{
+    return array_merge([
+        'title' => 'Residential Deep Cleaning Needed',
+        'cleaning_job_category_id' => CleaningJobCategory::factory()->create()->id,
+        'description' => 'Full description of the cleaning task.',
+        'country' => 'Philippines',
+        'city' => 'Cebu',
+        'schedule_date' => now()->addWeek()->toDateString(),
+    ], $overrides);
+}
+
+test('an employer can create a job post with media', function () {
+    Storage::fake('public');
+    $employer = User::factory()->employer()->create();
+    Sanctum::actingAs($employer);
+
+    $response = $this->post('/api/v1/cleaning-job-posts', validJobPostPayload([
+        'visibility' => 'published',
+        'pay_amount' => 30,
+        'pay_currency' => 'USD',
+        'start_time' => '09:00',
+        'media' => [UploadedFile::fake()->image('before.jpg')],
+    ]));
+
+    $response->assertCreated()
+        ->assertJsonPath('title', 'Residential Deep Cleaning Needed')
+        ->assertJsonPath('status', 'open')
+        ->assertJsonPath('visibility', 'published')
+        ->assertJsonPath('pay_amount', 30)
+        ->assertJsonPath('start_time', '09:00')
+        ->assertJsonCount(1, 'media')
+        ->assertJsonPath('applications_count', 0);
+
+    $post = CleaningJobPost::first();
+    expect($post->employer_id)->toBe($employer->id);
+    Storage::disk('public')->assertExists($post->media[0]['path']);
+});
+
+test('a cleaner cannot create a job post', function () {
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->postJson('/api/v1/cleaning-job-posts', validJobPostPayload())
+        ->assertForbidden();
+});
+
+test('a guest cannot create a job post', function () {
+    $this->postJson('/api/v1/cleaning-job-posts', validJobPostPayload())
+        ->assertUnauthorized();
+});
+
+test('a job post requires title, category, description, location, and date', function () {
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->postJson('/api/v1/cleaning-job-posts', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['title', 'cleaning_job_category_id', 'description', 'country', 'city', 'schedule_date']);
+});
+
+test('a job post title over 101 words is rejected', function () {
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->postJson('/api/v1/cleaning-job-posts', validJobPostPayload(['title' => trim(str_repeat('word ', 102))]))
+        ->assertStatus(422)->assertJsonValidationErrors('title');
+});
+
+test('non-image media is rejected', function () {
+    Storage::fake('public');
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->post('/api/v1/cleaning-job-posts', validJobPostPayload([
+        'media' => [UploadedFile::fake()->create('notes.pdf', 40, 'application/pdf')],
+    ]))->assertStatus(422)->assertJsonValidationErrors('media.0');
+});
+
+test('a schedule date in the past is rejected', function () {
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->postJson('/api/v1/cleaning-job-posts', validJobPostPayload(['schedule_date' => now()->subDay()->toDateString()]))
+        ->assertStatus(422)->assertJsonValidationErrors('schedule_date');
+});
+
+test('an application deadline after the schedule date is rejected', function () {
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->postJson('/api/v1/cleaning-job-posts', validJobPostPayload([
+        'schedule_date' => now()->addWeek()->toDateString(),
+        'application_deadline' => now()->addWeeks(2)->toDateString(),
+    ]))->assertStatus(422)->assertJsonValidationErrors('application_deadline');
+});
+
+test('an employer lists only their own posts via mine', function () {
+    $employer = User::factory()->employer()->create();
+    CleaningJobPost::factory()->count(2)->create(['employer_id' => $employer->id]);
+    CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id]);
+    CleaningJobPost::factory()->count(3)->create();
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine')
+        ->assertOk()
+        ->assertJsonCount(3, 'data')
+        ->assertJsonStructure(['data', 'links', 'meta']);
+});
+
+test('a guest cannot access the mine listing', function () {
+    $this->getJson('/api/v1/cleaning-job-posts/mine')->assertUnauthorized();
+});

--- a/tests/Feature/CleaningJobPostShowTest.php
+++ b/tests/Feature/CleaningJobPostShowTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Enums\JobPostStatus;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('a guest can view a published job post as a bare object', function () {
+    $post = CleaningJobPost::factory()->create([
+        'title' => 'Residential Deep Cleaning Needed',
+        'pay_amount' => 25.00,
+        'pay_currency' => 'USD',
+        'start_time' => '09:00:00',
+    ]);
+
+    $response = $this->getJson("/api/v1/cleaning-job-posts/{$post->id}");
+
+    $response->assertOk()
+        ->assertJsonPath('id', $post->id)
+        ->assertJsonPath('title', 'Residential Deep Cleaning Needed')
+        ->assertJsonPath('pay_amount', 25)
+        ->assertJsonPath('pay_currency', 'USD')
+        ->assertJsonPath('start_time', '09:00')
+        ->assertJsonPath('status', 'open')
+        ->assertJsonPath('visibility', 'published')
+        ->assertJsonPath('employer.rating_average', null)
+        ->assertJsonMissing(['slug' => $post->category->slug])
+        ->assertJsonMissingPath('applications_count')
+        ->assertJsonStructure(['category' => ['id', 'name'], 'employer' => ['id', 'name'], 'media']);
+});
+
+test('a guest cannot view a draft job post', function () {
+    $post = CleaningJobPost::factory()->draft()->create();
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")->assertNotFound();
+});
+
+test('a guest cannot view a removed job post', function () {
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Removed)->create();
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")->assertNotFound();
+});
+
+test('the owning employer can view their own draft job post', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonPath('id', $post->id)
+        ->assertJsonPath('visibility', 'draft')
+        ->assertJsonPath('applications_count', 0);
+});
+
+test('a different employer cannot view someone elses draft', function () {
+    $post = CleaningJobPost::factory()->draft()->create();
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")->assertNotFound();
+});
+
+test('viewing a missing job post returns 404', function () {
+    $this->getJson('/api/v1/cleaning-job-posts/999999')->assertNotFound();
+});

--- a/tests/Feature/CleaningJobPostUpdateTest.php
+++ b/tests/Feature/CleaningJobPostUpdateTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Enums\JobPostStatus;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+test('an employer can fully edit their own draft post and publish it', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id, 'title' => 'Old title']);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", [
+        'title' => 'Updated title',
+        'visibility' => 'published',
+    ])
+        ->assertOk()
+        ->assertJsonPath('title', 'Updated title')
+        ->assertJsonPath('visibility', 'published')
+        ->assertJsonPath('status', 'open');
+});
+
+test('the status of a draft post cannot be changed', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'reviewing'])
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('media on a draft post is replaced on update', function () {
+    Storage::fake('public');
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->draft()->create([
+        'employer_id' => $employer->id,
+        'media' => [['name' => 'old.jpg', 'path' => 'job-media/old.jpg']],
+    ]);
+
+    Sanctum::actingAs($employer);
+
+    $this->post("/api/v1/cleaning-job-posts/{$post->id}", [
+        '_method' => 'PATCH',
+        'media' => [UploadedFile::fake()->image('new1.jpg'), UploadedFile::fake()->image('new2.jpg')],
+    ])
+        ->assertOk()
+        ->assertJsonCount(2, 'media')
+        ->assertJsonPath('media.0.name', 'new1.jpg');
+});
+
+test('a published post can advance its status forward', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]); // published + open
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'completed'])
+        ->assertOk()
+        ->assertJsonPath('status', 'completed');
+});
+
+test('content edits on a published post are rejected', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['title' => 'Sneaky edit', 'pay_amount' => 999])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['title', 'pay_amount']);
+});
+
+test('a closed post cannot reopen but can complete', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Closed)->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'open'])
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'completed'])
+        ->assertOk()->assertJsonPath('status', 'completed');
+});
+
+test('a completed post status is terminal', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Completed)->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'reviewing'])
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('an employer cannot set the removed status', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'removed'])
+        ->assertStatus(422)->assertJsonValidationErrors('status');
+});
+
+test('an employer cannot update another employers post', function () {
+    $post = CleaningJobPost::factory()->draft()->create();
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['title' => 'Hijacked'])
+        ->assertForbidden();
+});
+
+test('a cleaner cannot update a job post', function () {
+    $post = CleaningJobPost::factory()->draft()->create();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['title' => 'Nope'])
+        ->assertForbidden();
+});
+
+test('an admin can soft-delete any job post', function () {
+    $post = CleaningJobPost::factory()->create();
+
+    Sanctum::actingAs(User::factory()->admin()->create());
+
+    $this->deleteJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonPath('message', 'Job post deleted.');
+
+    expect(CleaningJobPost::withTrashed()->find($post->id)->trashed())->toBeTrue();
+    expect(CleaningJobPost::find($post->id))->toBeNull();
+});
+
+test('an employer cannot delete their own job post', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+
+    Sanctum::actingAs($employer);
+
+    $this->deleteJson("/api/v1/cleaning-job-posts/{$post->id}")->assertForbidden();
+    expect(CleaningJobPost::find($post->id))->not->toBeNull();
+});
+
+test('a soft-deleted post cannot be updated or viewed', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id]);
+    $post->delete();
+
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['title' => 'x'])->assertNotFound();
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")->assertNotFound();
+});

--- a/tests/Feature/EmployerJobListingTest.php
+++ b/tests/Feature/EmployerJobListingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\JobPostStatus;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+test('guests cannot view an employer job listing', function () {
+    $employer = User::factory()->employer()->create();
+
+    $this->getJson("/api/v1/employers/{$employer->id}/cleaning-job-posts")
+        ->assertUnauthorized();
+});
+
+test('an authenticated user sees an employer published posts across all non-removed statuses', function () {
+    $employer = User::factory()->employer()->create();
+    CleaningJobPost::factory()->create(['employer_id' => $employer->id]); // published + open
+    CleaningJobPost::factory()->status(JobPostStatus::Closed)->create(['employer_id' => $employer->id]);
+    CleaningJobPost::factory()->status(JobPostStatus::Completed)->create(['employer_id' => $employer->id]);
+
+    // excluded: draft (not public) and removed (hidden)
+    CleaningJobPost::factory()->draft()->create(['employer_id' => $employer->id]);
+    CleaningJobPost::factory()->status(JobPostStatus::Removed)->create(['employer_id' => $employer->id]);
+
+    // another employer's post must not appear
+    CleaningJobPost::factory()->create();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson("/api/v1/employers/{$employer->id}/cleaning-job-posts")
+        ->assertOk()
+        ->assertJsonCount(3, 'data')
+        ->assertJsonStructure([
+            'data' => [['id', 'title', 'status', 'category' => ['id', 'name'], 'employer' => ['id', 'name']]],
+            'links',
+            'meta',
+        ]);
+});
+
+test('requesting a non-employer id returns 404', function () {
+    $cleaner = User::factory()->cleaner()->create();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson("/api/v1/employers/{$cleaner->id}/cleaning-job-posts")->assertNotFound();
+    $this->getJson('/api/v1/employers/999999/cleaning-job-posts')->assertNotFound();
+});


### PR DESCRIPTION
## Summary

Implements the full server-side job post lifecycle — schema, model, endpoints, authorization, validation, seeding, and feature tests. Employers can create and manage job posts; cleaners and guests can browse and view them through role-aware visibility rules.

---

## What's changed

**Schema & model**

- New `cleaning_job_posts` table via migration (`2026_07_22_132355`) with soft-deletes and indexed columns for `country`, `city`, `schedule_date`, `visibility`, `status`, and `pay_amount`.
- `CleaningJobPost` Eloquent model with:
  - `JobPostStatus` enum: `open`, `reviewing`, `closed`, `removed`, `completed`
  - `JobPostVisibility` enum: `draft`, `published`
  - Named query scopes: `published()`, `open()`, `notRemoved()`
  - Soft-delete support via `SoftDeletes`
  - `BelongsTo` relations to `User` (employer) and `CleaningJobCategory`
- `CleaningJobPostFactory` for use in seeders and tests.

**API endpoints** (all under `/api/v1`)

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/cleaning-job-posts` | Guest / Auth | Browse published posts — keyword search, filter, sort, pagination |
| `GET` | `/cleaning-job-posts/{id}` | Guest / Auth | Public job detail; owner sees own post in any status |
| `GET` | `/cleaning-job-posts/mine` | Employer | Employer's own posts (all statuses) with search/filter |
| `POST` | `/cleaning-job-posts` | Employer | Create a new job post (supports media upload via `FormData`) |
| `PATCH` | `/cleaning-job-posts/{id}` | Employer (owner) | Update title, details, status, visibility, and media |
| `DELETE` | `/cleaning-job-posts/{id}` | Admin only | Soft-delete; employers cannot delete their own posts |
| `GET` | `/employers/{id}/cleaning-job-posts` | Auth | Public job history for a given employer profile |

**Authorization**

- `CleaningJobPostPolicy`: employers can create and update their own posts; `delete` always returns `false` so only admin (via `Gate::before` superuser bypass) can remove a post.
- Public `index` visibility rules:
  - Guests and cleaners: `open` posts only.
  - A searching cleaner additionally sees non-`removed` posts (e.g. `reviewing`, `closed`, `completed`).
  - Employers / moderators / admin: can filter by any status including `removed`.
- `applications_count` in `CleaningJobPostResource` is conditionally exposed — only returned when the authenticated viewer is the owning employer.

**Request validation**

- `StoreCleaningJobPostRequest` — required: title, category, description, country, city, schedule date, visibility. Optional: requirements, qualifications, address, start/end times, deadline, pay amount/currency, media.
- `UpdateCleaningJobPostRequest` — same field set, all optional (PATCH semantics); additionally exposes `status` and `visibility` as owner-updatable.

**Seeder**

- `DemoJobPostSeeder` — idempotent (keyed on employer + title), creates demo posts across multiple categories, statuses, visibilities, pay currencies, and media attachments for `employer1@demo.test`, `employer2@demo.test`, and `employer3@demo.test`. Depends on `DemoProfileSeeder` having run first.
- Wired into `DatabaseSeeder`.

**Feature tests** (5 new files)

- `CleaningJobPostBrowseTest` — guest vs. cleaner vs. employer filter and search scope rules, pagination
- `CleaningJobPostShowTest` — public visibility rules; owner access to draft/removed posts
- `CleaningJobPostManageTest` — create, update, and policy authorization checks
- `CleaningJobPostUpdateTest` — PATCH field-by-field coverage and ownership enforcement
- `EmployerJobListingTest` — `/employers/{id}/cleaning-job-posts` endpoint coverage

---

### Minor changes

- `high_pay` sort option removed from the public browse endpoint. 
- The `top_employer` sort is registered but currently falls back to `newest`.
- `DatabaseSeeder` updated to call `DemoJobPostSeeder` after `DemoProfileSeeder`.

---

### Rollback

> ⚠️ Only needed if this PR is reverted after merge to `staging`.

1. Roll back the migration on the affected environment:
   ```bash
   php artisan migrate:rollback --step=1
   # Drops the `cleaning_job_posts` table; soft-deleted rows are included.
   ```
2. Uploaded media files in `storage/app/public/` (if any `store` requests ran in the environment) must be removed manually — identify paths from application logs before rolling back the migration.
   ```bash
   # Example — adjust path to match your storage configuration:
   rm -rf storage/app/public/job-media/
   ```
3. No other database tables are affected.