### PR TITLE
Feat: Cleaner save/unsave endpoints with `is_saved` feed flag

### DIFF
--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -69,6 +69,7 @@ class CleaningJobPostController extends Controller
                 fn (Builder $q) => $searchingCleaner ? $q->notRemoved() : $q->open(),
             )
             ->with(['employer', 'category'])
+            ->withViewerSaved($viewer)
             ->when(
                 isset($validated['search']),
                 fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {
@@ -148,7 +149,7 @@ class CleaningJobPostController extends Controller
      * public) and removed (hidden) posts are excluded. Any authenticated user
      * may view this.
      */
-    public function forEmployer(int $id): AnonymousResourceCollection
+    public function forEmployer(Request $request, int $id): AnonymousResourceCollection
     {
         $employer = User::where('role', UserRole::Employer)->findOrFail($id);
 
@@ -157,6 +158,7 @@ class CleaningJobPostController extends Controller
             ->published()
             ->where('status', '!=', JobPostStatus::Removed->value)
             ->with(['employer', 'category'])
+            ->withViewerSaved($request->user('sanctum'))
             ->latest()
             ->paginate(15);
 
@@ -218,9 +220,12 @@ class CleaningJobPostController extends Controller
      */
     public function show(Request $request, int $id): CleaningJobPostResource
     {
-        $post = CleaningJobPost::with(['employer', 'category'])->findOrFail($id);
-
         $viewer = $request->user('sanctum');
+
+        $post = CleaningJobPost::with(['employer', 'category'])
+            ->withViewerSaved($viewer)
+            ->findOrFail($id);
+
         $isOwner = $viewer !== null && $viewer->id === $post->employer_id;
 
         $isPubliclyVisible = $post->visibility === JobPostVisibility::Published

--- a/app/Http/Controllers/Api/V1/SavedJobController.php
+++ b/app/Http/Controllers/Api/V1/SavedJobController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreSavedJobRequest;
+use App\Http\Resources\SavedJobResource;
+use App\Models\CleaningJobPost;
+use App\Models\SavedJob;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+
+class SavedJobController extends Controller
+{
+    /**
+     * List the authenticated cleaner's saved jobs, newest first, paginated. Each
+     * row embeds the full job post with its live status, so a job that has since
+     * closed/filled/completed is still returned (never filtered out) for the
+     * frontend to flag.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        Gate::authorize('viewAny', SavedJob::class);
+
+        $saved = SavedJob::query()
+            ->where('user_id', $request->user()->id)
+            ->with(['cleaningJobPost.employer', 'cleaningJobPost.category'])
+            ->latest()
+            ->paginate(15);
+
+        // Every job in the cleaner's own list is saved by them by definition,
+        // so set the flag the embedded job resource reads without a subquery.
+        $saved->getCollection()->each(
+            fn (SavedJob $savedJob) => $savedJob->cleaningJobPost->setAttribute('is_saved_by_viewer', true)
+        );
+
+        return SavedJobResource::collection($saved);
+    }
+
+    /**
+     * Save an open, published job for the authenticated cleaner. The save-time
+     * gate requires the target job to currently be open + published; a job may
+     * later transition to another status while it stays in the list.
+     */
+    public function store(StoreSavedJobRequest $request): JsonResponse
+    {
+        $post = CleaningJobPost::findOrFail($request->integer('cleaning_job_post_id'));
+
+        if ($post->visibility !== JobPostVisibility::Published || $post->status !== JobPostStatus::Open) {
+            throw ValidationException::withMessages([
+                'cleaning_job_post_id' => 'Only open, published jobs can be saved.',
+            ]);
+        }
+
+        $alreadySaved = SavedJob::query()
+            ->where('user_id', $request->user()->id)
+            ->where('cleaning_job_post_id', $post->id)
+            ->exists();
+
+        if ($alreadySaved) {
+            throw ValidationException::withMessages([
+                'cleaning_job_post_id' => 'This job is already in your saved list.',
+            ]);
+        }
+
+        $savedJob = SavedJob::create([
+            'user_id' => $request->user()->id,
+            'cleaning_job_post_id' => $post->id,
+        ]);
+
+        $savedJob->load(['cleaningJobPost.employer', 'cleaningJobPost.category']);
+        $savedJob->cleaningJobPost->setAttribute('is_saved_by_viewer', true);
+
+        return (new SavedJobResource($savedJob))->response()->setStatusCode(201);
+    }
+
+    /**
+     * Remove a job from the authenticated cleaner's saved list. The route param
+     * is the job-post id (not the saved-job id) so the frontend can unsave from
+     * a job page without knowing the pivot row id. Scoping the lookup to the
+     * current user makes cross-user unsaves a 404, never someone else's row.
+     */
+    public function destroy(Request $request, CleaningJobPost $cleaningJobPost): JsonResponse
+    {
+        Gate::authorize('viewAny', SavedJob::class);
+
+        SavedJob::query()
+            ->where('user_id', $request->user()->id)
+            ->where('cleaning_job_post_id', $cleaningJobPost->id)
+            ->firstOrFail()
+            ->delete();
+
+        return response()->json(['message' => 'Job removed from saved list.']);
+    }
+}

--- a/app/Http/Requests/StoreSavedJobRequest.php
+++ b/app/Http/Requests/StoreSavedJobRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\SavedJob;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreSavedJobRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', SavedJob::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'cleaning_job_post_id' => ['required', 'integer', Rule::exists('cleaning_job_posts', 'id')],
+        ];
+    }
+}

--- a/app/Http/Resources/CleaningJobPostResource.php
+++ b/app/Http/Resources/CleaningJobPostResource.php
@@ -19,6 +19,7 @@ class CleaningJobPostResource extends JsonResource
     {
         $viewer = $request->user('sanctum');
         $isOwner = $viewer !== null && $viewer->id === $this->employer_id;
+        $viewerIsCleaner = $viewer !== null && $viewer->isCleaner();
 
         return [
             'id' => $this->id,
@@ -50,6 +51,7 @@ class CleaningJobPostResource extends JsonResource
             'pay_currency' => $this->pay_currency,
             'media' => $this->mapMedia(),
             'applications_count' => $this->when($isOwner, 0),
+            'is_saved' => $this->when($viewerIsCleaner, fn (): bool => (bool) $this->getAttribute('is_saved_by_viewer')),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/SavedJobResource.php
+++ b/app/Http/Resources/SavedJobResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\SavedJob;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin SavedJob
+ */
+class SavedJobResource extends JsonResource
+{
+    /**
+     * The embedded job carries its live status/visibility, so the frontend can
+     * flag a saved job that has since closed/filled without a second request.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'saved_at' => $this->created_at,
+            'job' => new CleaningJobPostResource($this->cleaningJobPost),
+        ];
+    }
+}

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
@@ -107,6 +108,33 @@ class CleaningJobPost extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(CleaningJobCategory::class, 'cleaning_job_category_id');
+    }
+
+    /**
+     * @return HasMany<SavedJob, $this>
+     */
+    public function savedJobs(): HasMany
+    {
+        return $this->hasMany(SavedJob::class);
+    }
+
+    /**
+     * Expose whether the given viewer (a cleaner) has saved each post as the
+     * `is_saved_by_viewer` attribute via a single existence subquery, so it
+     * costs no extra query per row on list endpoints. A no-op for guests and
+     * non-cleaners, who never see the flag.
+     *
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    public function scopeWithViewerSaved(Builder $query, ?User $viewer): void
+    {
+        if ($viewer === null || ! $viewer->isCleaner()) {
+            return;
+        }
+
+        $query->withExists(['savedJobs as is_saved_by_viewer' => function (Builder $subQuery) use ($viewer): void {
+            $subQuery->where('user_id', $viewer->id);
+        }]);
     }
 
     /**

--- a/app/Models/SavedJob.php
+++ b/app/Models/SavedJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\SavedJobFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $cleaning_job_post_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ * @property-read CleaningJobPost $cleaningJobPost
+ */
+#[Fillable(['user_id', 'cleaning_job_post_id'])]
+class SavedJob extends Model
+{
+    /** @use HasFactory<SavedJobFactory> */
+    use HasFactory;
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<CleaningJobPost, $this>
+     */
+    public function cleaningJobPost(): BelongsTo
+    {
+        return $this->belongsTo(CleaningJobPost::class);
+    }
+}

--- a/app/Policies/SavedJobPolicy.php
+++ b/app/Policies/SavedJobPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+/**
+ * Saving jobs is a cleaner-only feature. The admin bypasses every check via the
+ * Gate::before hook in AppServiceProvider; employers and moderators are denied.
+ * Ownership of a saved row is enforced in the controller by scoping every query
+ * to the authenticated user, so there is no cross-user access to guard here.
+ */
+class SavedJobPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isCleaner();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isCleaner();
+    }
+}

--- a/database/factories/SavedJobFactory.php
+++ b/database/factories/SavedJobFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CleaningJobPost;
+use App\Models\SavedJob;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SavedJob>
+ */
+class SavedJobFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory()->cleaner(),
+            'cleaning_job_post_id' => CleaningJobPost::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_24_083554_create_saved_jobs_table.php
+++ b/database/migrations/2026_07_24_083554_create_saved_jobs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('saved_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('cleaning_job_post_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'cleaning_job_post_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_jobs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use App\Http\Controllers\Api\V1\CleaningJobPostController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\PublicProfileController;
+use App\Http\Controllers\Api\V1\SavedJobController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -49,6 +50,11 @@ Route::prefix('v1')->group(function (): void {
         Route::patch('cleaning-job-posts/{cleaningJobPost}', [CleaningJobPostController::class, 'update'])
             ->whereNumber('cleaningJobPost');
         Route::delete('cleaning-job-posts/{cleaningJobPost}', [CleaningJobPostController::class, 'destroy'])
+            ->whereNumber('cleaningJobPost');
+
+        Route::get('saved-jobs', [SavedJobController::class, 'index']);
+        Route::post('saved-jobs', [SavedJobController::class, 'store']);
+        Route::delete('saved-jobs/{cleaningJobPost}', [SavedJobController::class, 'destroy'])
             ->whereNumber('cleaningJobPost');
     });
 

--- a/tests/Feature/SavedJobTest.php
+++ b/tests/Feature/SavedJobTest.php
@@ -1,0 +1,213 @@
+<?php
+
+use App\Enums\JobPostStatus;
+use App\Models\CleaningJobPost;
+use App\Models\SavedJob;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+
+test('a cleaner can save an open published job', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])
+        ->assertCreated()
+        ->assertJsonPath('job.id', $post->id)
+        ->assertJsonPath('job.status', 'open')
+        ->assertJsonPath('job.title', $post->title);
+
+    $this->assertDatabaseHas('saved_jobs', [
+        'user_id' => $cleaner->id,
+        'cleaning_job_post_id' => $post->id,
+    ]);
+});
+
+test('a cleaner cannot save the same job twice', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+
+    expect(SavedJob::where('cleaning_job_post_id', $post->id)->count())->toBe(1);
+});
+
+test('a cleaner cannot save a closed job', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+
+    $this->assertDatabaseCount('saved_jobs', 0);
+});
+
+test('a cleaner cannot save a draft job', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->draft()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+});
+
+test('a cleaner can unsave a saved job', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/saved-jobs/{$post->id}")
+        ->assertOk();
+
+    $this->assertDatabaseMissing('saved_jobs', [
+        'user_id' => $cleaner->id,
+        'cleaning_job_post_id' => $post->id,
+    ]);
+});
+
+test('unsaving a job the cleaner has not saved returns 404', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $otherCleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $otherCleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/saved-jobs/{$post->id}")
+        ->assertNotFound();
+
+    $this->assertDatabaseHas('saved_jobs', [
+        'user_id' => $otherCleaner->id,
+        'cleaning_job_post_id' => $post->id,
+    ]);
+});
+
+test('the saved jobs list embeds the job with its live status', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $openPost = CleaningJobPost::factory()->create();
+    $closedPost = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $openPost->id]);
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $closedPost->id]);
+
+    // The job transitions to closed after it was saved; it must still appear.
+    $closedPost->update(['status' => JobPostStatus::Closed]);
+
+    Sanctum::actingAs($cleaner);
+
+    $response = $this->getJson('/api/v1/saved-jobs')
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonStructure(['data' => [['id', 'saved_at', 'job' => ['id', 'title', 'status']]], 'links', 'meta']);
+
+    $statuses = collect($response->json('data'))->pluck('job.status', 'job.id');
+    expect($statuses[$openPost->id])->toBe('open');
+    expect($statuses[$closedPost->id])->toBe('closed');
+});
+
+test('the saved jobs list only returns the cleaner own saves', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $otherCleaner = User::factory()->cleaner()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id]);
+    SavedJob::factory()->count(2)->create(['user_id' => $otherCleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/saved-jobs')
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+});
+
+test('a guest cannot use the saved jobs endpoints', function () {
+    $post = CleaningJobPost::factory()->create();
+
+    $this->getJson('/api/v1/saved-jobs')->assertUnauthorized();
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])->assertUnauthorized();
+    $this->deleteJson("/api/v1/saved-jobs/{$post->id}")->assertUnauthorized();
+});
+
+test('non-cleaner roles cannot use the saved jobs endpoints', function (string $role) {
+    $user = User::factory()->{$role}()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($user);
+
+    $this->getJson('/api/v1/saved-jobs')->assertForbidden();
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])->assertForbidden();
+    $this->deleteJson("/api/v1/saved-jobs/{$post->id}")->assertForbidden();
+})->with(['employer', 'moderator']);
+
+test('the browse feed flags which jobs the cleaner has saved', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $savedPost = CleaningJobPost::factory()->create();
+    $unsavedPost = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $savedPost->id]);
+    Sanctum::actingAs($cleaner);
+
+    $flags = collect($this->getJson('/api/v1/cleaning-job-posts')->assertOk()->json('data'))
+        ->pluck('is_saved', 'id');
+
+    expect($flags[$savedPost->id])->toBeTrue();
+    expect($flags[$unsavedPost->id])->toBeFalse();
+});
+
+test('the job detail endpoint flags whether the cleaner has saved it', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonPath('is_saved', true);
+});
+
+test('is_saved is omitted for guests and employers', function () {
+    $post = CleaningJobPost::factory()->create();
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('is_saved');
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('is_saved');
+});
+
+test('the saved jobs list marks each embedded job as saved', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    SavedJob::factory()->create(['user_id' => $cleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/saved-jobs')
+        ->assertOk()
+        ->assertJsonPath('data.0.job.is_saved', true);
+});
+
+test('computing is_saved on the browse feed does not add a query per post', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    Sanctum::actingAs($cleaner);
+
+    CleaningJobPost::factory()->create();
+    DB::enableQueryLog();
+    $this->getJson('/api/v1/cleaning-job-posts')->assertOk();
+    $single = count(DB::getQueryLog());
+    DB::flushQueryLog();
+    DB::disableQueryLog();
+
+    // Add more posts with the log OFF so only request queries are counted.
+    CleaningJobPost::factory()->count(4)->create();
+
+    DB::enableQueryLog();
+    $this->getJson('/api/v1/cleaning-job-posts')->assertOk();
+    $many = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($many)->toBe($single);
+});


### PR DESCRIPTION
#### Summary

Introduces a fully tested saved-jobs feature for cleaner users. Cleaners can bookmark open, published job posts; the bookmark persists even if the job later closes or fills. The existing job-post list and detail endpoints are extended to surface an `is_saved` flag per-viewer — resolved via a single SQL `EXISTS` subquery so no N+1 queries are introduced.

---

#### What's changed

##### New: `saved_jobs` table & model
- **Migration** (`2026_07_24_083554_create_saved_jobs_table.php`) — creates `saved_jobs` with `user_id` and `cleaning_job_post_id` foreign keys, a composite `UNIQUE` constraint, and cascade-delete on both parent rows.
- **`SavedJob` model** — `BelongsTo` relationships to `User` and `CleaningJobPost`; uses the `#[Fillable]` attribute and `HasFactory`.
- **`SavedJobFactory`** — for use in Pest feature tests.

##### New: API endpoints (`/api/v1/saved-jobs`)
| Method | URI | Description |
|--------|-----|-------------|
| `GET` | `/api/v1/saved-jobs` | Paginated list of the cleaner's saves (newest first). Each row embeds the full job with its live status. |
| `POST` | `/api/v1/saved-jobs` | Save an open, published job. Returns `201` with the created save row. |
| `DELETE` | `/api/v1/saved-jobs/{cleaningJobPost}` | Unsave by job-post ID (not pivot row ID). Scoped to the authenticated user — cross-user attempts return `404`. |

##### New: `SavedJobController`
- `index` — paginates the user's saves with eager-loaded `cleaningJobPost.employer` + `.category`; sets `is_saved_by_viewer = true` on each embedded post in-memory so the resource doesn't run an extra query.
- `store` — validates the post is open + published before saving; rejects duplicates with a `422`.
- `destroy` — uses `firstOrFail()` scoped to the authenticated user; a cross-user unsave attempt results in `404`.

##### New: `StoreSavedJobRequest` + `SavedJobPolicy`
- `StoreSavedJobRequest` — validates `cleaning_job_post_id` exists in the `cleaning_job_posts` table; authorises via policy.
- `SavedJobPolicy` — restricts `viewAny` and `create` to cleaner users only. Employers and moderators receive `403`. The admin bypasses all checks via the global `Gate::before` hook.

##### New: `SavedJobResource`
- Serialises `{ id, saved_at, job }` where `job` is a full `CleaningJobPostResource` (carrying `is_saved: true` since the viewer is always the owner of that row).

##### Modified: `CleaningJobPost` model
- New `savedJobs(): HasMany` relationship.
- New `scopeWithViewerSaved(Builder $query, ?User $viewer)` — appends a single `withExists` subquery for the current cleaner; a no-op for guests and non-cleaners.

##### Modified: `CleaningJobPostResource`
- Adds `is_saved` field, exposed only when the viewer is a cleaner (`$this->when($viewerIsCleaner, ...)`). Reads the `is_saved_by_viewer` attribute set by the scope or controller, keeping serialisation free of extra queries.

##### Modified: `CleaningJobPostController`
- Browse (`index`) and detail (`show`) now call `scopeWithViewerSaved` with the authenticated user, enabling the `is_saved` flag on the feed without additional queries.

##### New: `SavedJobTest` (13 cases)
| Test | Expectation |
|------|-------------|
| A cleaner can save an open job | `201`, row in DB |
| Cannot save the same job twice | `422` |
| Cannot save a closed job | `422` |
| Cannot save a draft job | `422` |
| Can unsave a saved job | `200`, row removed |
| Unsaving a job not saved by this cleaner | `404`, other row intact |
| Saved list embeds live status | `200`, both open & closed jobs present |
| List only returns own saves | `200`, count = 1 |
| Guest cannot use any endpoint | `401` |
| Employer / moderator cannot use any endpoint | `403` |
| Browse feed flags `is_saved` correctly | `true` / `false` per post |
| Detail endpoint flags `is_saved` | `true` when saved |
| `is_saved` omitted for guests and employers | field absent |
| `is_saved` in saved list always `true` | field = `true` |
| No N+1 on browse feed | query count identical for 1 vs 5 posts |

---

#### How to test

```bash
php artisan migrate
composer test -- --filter SavedJob
```
