### PR TITLE
Feat: Cleaner apply flow and employer applicant management

### DIFF
--- a/app/Enums/ApplicationStatus.php
+++ b/app/Enums/ApplicationStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum ApplicationStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Withdrawn = 'withdrawn';
+    case Completed = 'completed';
+}

--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreApplicationRequest;
+use App\Http\Resources\ApplicationResource;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\SavedJob;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use RuntimeException;
+
+class ApplicationController extends Controller
+{
+    /**
+     * List the authenticated cleaner's own applications, newest first,
+     * paginated, optionally narrowed to one status tab. Each row embeds the full
+     * job post with its live status, so an application to a job that has since
+     * closed is still returned for the frontend to flag.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        Gate::authorize('viewAny', Application::class);
+
+        $validated = $request->validate([
+            'status' => ['sometimes', Rule::enum(ApplicationStatus::class)],
+        ]);
+
+        $applications = Application::query()
+            ->where('user_id', $request->user()->id)
+            ->when(isset($validated['status']), fn (Builder $query) => $query->where('status', $validated['status']))
+            ->with(['cleaningJobPost.employer', 'cleaningJobPost.category'])
+            ->latest()
+            ->paginate(15);
+
+        $this->attachViewerFlags($applications->getCollection(), $request->user());
+
+        return ApplicationResource::collection($applications);
+    }
+
+    /**
+     * Apply to an open, published job as the authenticated cleaner. The unique
+     * (cleaning_job_post_id, user_id) index is the permanent guard against a
+     * second application; the duplicate check here turns that into a readable
+     * 422 instead of a database error. Both rejections report on
+     * cleaning_job_post_id and differ only by message, matching
+     * SavedJobController::store().
+     */
+    public function store(StoreApplicationRequest $request): JsonResponse
+    {
+        $post = CleaningJobPost::findOrFail($request->integer('cleaning_job_post_id'));
+
+        if ($post->visibility !== JobPostVisibility::Published || $post->status !== JobPostStatus::Open) {
+            throw ValidationException::withMessages([
+                'cleaning_job_post_id' => 'This job is no longer accepting applications.',
+            ]);
+        }
+
+        $alreadyApplied = Application::query()
+            ->where('user_id', $request->user()->id)
+            ->where('cleaning_job_post_id', $post->id)
+            ->exists();
+
+        if ($alreadyApplied) {
+            throw ValidationException::withMessages([
+                'cleaning_job_post_id' => 'You have already applied to this job.',
+            ]);
+        }
+
+        $application = new Application([
+            'cleaning_job_post_id' => $post->id,
+            'user_id' => $request->user()->id,
+            'message' => $request->input('message'),
+        ]);
+
+        if ($request->hasFile('resume')) {
+            $application->resume_path = $this->storeResume($request->file('resume'));
+        }
+
+        $application->save();
+        $application->load(['cleaningJobPost.employer', 'cleaningJobPost.category']);
+
+        $this->attachViewerFlags(new Collection([$application]), $request->user());
+
+        return (new ApplicationResource($application))->response()->setStatusCode(201);
+    }
+
+    /**
+     * Withdraw a pending application. This is a status transition, not a delete:
+     * the row must survive so the unique constraint keeps blocking a re-apply.
+     */
+    public function destroy(Application $application): JsonResponse
+    {
+        Gate::authorize('withdraw', $application);
+
+        $application->update(['status' => ApplicationStatus::Withdrawn]);
+
+        return response()->json(['message' => 'Application withdrawn.']);
+    }
+
+    /**
+     * The embedded job posts are loaded through the application, so the viewer
+     * flags CleaningJobPostResource reads are not set by a query scope here.
+     * Every job in this list is applied to by the viewer by definition; saved
+     * state costs one extra lookup for the whole page rather than one per row.
+     *
+     * @param  Collection<int, Application>  $applications
+     */
+    protected function attachViewerFlags(Collection $applications, User $viewer): void
+    {
+        $savedPostIds = SavedJob::query()
+            ->where('user_id', $viewer->id)
+            ->whereIn('cleaning_job_post_id', $applications->pluck('cleaning_job_post_id'))
+            ->pluck('cleaning_job_post_id')
+            ->all();
+
+        $applications->each(function (Application $application) use ($savedPostIds): void {
+            $application->cleaningJobPost
+                ->setAttribute('is_saved_by_viewer', in_array($application->cleaning_job_post_id, $savedPostIds, true))
+                ->setAttribute('has_applied_by_viewer', true)
+                ->setAttribute('viewer_application_status_raw', $application->status->value);
+        });
+    }
+
+    /**
+     * Store an uploaded resume on the public disk, failing fast if the write
+     * does not succeed.
+     */
+    protected function storeResume(UploadedFile $file): string
+    {
+        $path = $file->store('application-resumes', 'public');
+
+        if ($path === false) {
+            throw new RuntimeException('Failed to store uploaded resume.');
+        }
+
+        return $path;
+    }
+}

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -69,7 +69,9 @@ class CleaningJobPostController extends Controller
                 fn (Builder $q) => $searchingCleaner ? $q->notRemoved() : $q->open(),
             )
             ->with(['employer', 'category'])
+            ->withCount('applications')
             ->withViewerSaved($viewer)
+            ->withViewerApplication($viewer)
             ->when(
                 isset($validated['search']),
                 fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {
@@ -123,6 +125,7 @@ class CleaningJobPostController extends Controller
         $query = CleaningJobPost::query()
             ->where('employer_id', $request->user()->id)
             ->with(['employer', 'category'])
+            ->withCount('applications')
             ->when(
                 isset($validated['search']),
                 fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {
@@ -158,7 +161,9 @@ class CleaningJobPostController extends Controller
             ->published()
             ->where('status', '!=', JobPostStatus::Removed->value)
             ->with(['employer', 'category'])
+            ->withCount('applications')
             ->withViewerSaved($request->user('sanctum'))
+            ->withViewerApplication($request->user('sanctum'))
             ->latest()
             ->paginate(15);
 
@@ -179,6 +184,7 @@ class CleaningJobPostController extends Controller
 
         $post->save();
         $post->load(['employer', 'category']);
+        $post->loadCount('applications');
 
         return (new CleaningJobPostResource($post))->response()->setStatusCode(201);
     }
@@ -197,6 +203,7 @@ class CleaningJobPostController extends Controller
 
         $cleaningJobPost->save();
         $cleaningJobPost->load(['employer', 'category']);
+        $cleaningJobPost->loadCount('applications');
 
         return new CleaningJobPostResource($cleaningJobPost);
     }
@@ -223,7 +230,9 @@ class CleaningJobPostController extends Controller
         $viewer = $request->user('sanctum');
 
         $post = CleaningJobPost::with(['employer', 'category'])
+            ->withCount('applications')
             ->withViewerSaved($viewer)
+            ->withViewerApplication($viewer)
             ->findOrFail($id);
 
         $isOwner = $viewer !== null && $viewer->id === $post->employer_id;

--- a/app/Http/Controllers/Api/V1/JobApplicantController.php
+++ b/app/Http/Controllers/Api/V1/JobApplicantController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\ApplicationStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\DecideApplicationRequest;
+use App\Http\Requests\UpdateApplicationNoteRequest;
+use App\Http\Resources\ApplicationResource;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+
+class JobApplicantController extends Controller
+{
+    /**
+     * List the applicants of one of the authenticated employer's job posts.
+     * The ability lives on ApplicationPolicy but is checked against the job
+     * post, so the leading class string is what routes the check there instead
+     * of to CleaningJobPostPolicy.
+     */
+    public function index(CleaningJobPost $cleaningJobPost): AnonymousResourceCollection
+    {
+        Gate::authorize('viewApplicants', [Application::class, $cleaningJobPost]);
+
+        $applications = Application::query()
+            ->where('cleaning_job_post_id', $cleaningJobPost->id)
+            ->where('status', '!=', ApplicationStatus::Withdrawn)
+            ->with(['user.cleanerProfile'])
+            ->latest()
+            ->paginate(15);
+
+        // Applicants who withdrew drop out of the list the employer works
+        // through, but the employer still gets to see how many there were.
+        $withdrawnCount = Application::query()
+            ->where('cleaning_job_post_id', $cleaningJobPost->id)
+            ->where('status', ApplicationStatus::Withdrawn)
+            ->count();
+
+        return ApplicationResource::collection($applications)
+            ->additional(['meta' => ['withdrawn_count' => $withdrawnCount]]);
+    }
+
+    /**
+     * Show a single application. Readable by both sides: the cleaner who
+     * submitted it and the employer who owns the job post.
+     */
+    public function show(Application $application): ApplicationResource
+    {
+        Gate::authorize('view', $application);
+
+        $application->load(['user.cleanerProfile', 'cleaningJobPost.employer', 'cleaningJobPost.category']);
+
+        return new ApplicationResource($application);
+    }
+
+    /**
+     * Accept an applicant. This is the only place that ever sets `accepted`,
+     * and accepting is what surfaces the job on the cleaner's calendar.
+     */
+    public function accept(DecideApplicationRequest $request, Application $application): ApplicationResource
+    {
+        return $this->decide($request, $application, ApplicationStatus::Accepted);
+    }
+
+    /**
+     * Reject an applicant.
+     */
+    public function reject(DecideApplicationRequest $request, Application $application): ApplicationResource
+    {
+        return $this->decide($request, $application, ApplicationStatus::Rejected);
+    }
+
+    /**
+     * Set or clear the employer's private note on an applicant. Never visible
+     * to the cleaner — ApplicationResource only emits it to employers.
+     */
+    public function note(UpdateApplicationNoteRequest $request, Application $application): ApplicationResource
+    {
+        $application->private_note = $request->input('note');
+        $application->save();
+
+        $application->load(['user.cleanerProfile']);
+
+        return new ApplicationResource($application);
+    }
+
+    /**
+     * Move a still-pending application to a decided status, optionally with a
+     * message for the cleaner. Anything already decided (or withdrawn by the
+     * cleaner) is a 422 rather than a silent overwrite. Authorization lives on
+     * DecideApplicationRequest, same as the note endpoint.
+     */
+    protected function decide(
+        DecideApplicationRequest $request,
+        Application $application,
+        ApplicationStatus $status,
+    ): ApplicationResource {
+        if ($application->status !== ApplicationStatus::Pending) {
+            throw ValidationException::withMessages([
+                'status' => 'This application has already been decided.',
+            ]);
+        }
+
+        $application->update([
+            'status' => $status,
+            'decision_message' => $request->validated('message'),
+        ]);
+
+        $application->load(['user.cleanerProfile']);
+
+        return new ApplicationResource($application);
+    }
+}

--- a/app/Http/Controllers/Api/V1/SavedJobController.php
+++ b/app/Http/Controllers/Api/V1/SavedJobController.php
@@ -2,16 +2,20 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Enums\ApplicationStatus;
 use App\Enums\JobPostStatus;
 use App\Enums\JobPostVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreSavedJobRequest;
 use App\Http\Resources\SavedJobResource;
+use App\Models\Application;
 use App\Models\CleaningJobPost;
 use App\Models\SavedJob;
+use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
 
@@ -33,11 +37,7 @@ class SavedJobController extends Controller
             ->latest()
             ->paginate(15);
 
-        // Every job in the cleaner's own list is saved by them by definition,
-        // so set the flag the embedded job resource reads without a subquery.
-        $saved->getCollection()->each(
-            fn (SavedJob $savedJob) => $savedJob->cleaningJobPost->setAttribute('is_saved_by_viewer', true)
-        );
+        $this->attachViewerFlags($saved->getCollection(), $request->user());
 
         return SavedJobResource::collection($saved);
     }
@@ -74,9 +74,34 @@ class SavedJobController extends Controller
         ]);
 
         $savedJob->load(['cleaningJobPost.employer', 'cleaningJobPost.category']);
-        $savedJob->cleaningJobPost->setAttribute('is_saved_by_viewer', true);
+
+        $this->attachViewerFlags(new Collection([$savedJob]), $request->user());
 
         return (new SavedJobResource($savedJob))->response()->setStatusCode(201);
+    }
+
+    /**
+     * The embedded job posts are loaded through the saved row, so the viewer
+     * flags CleaningJobPostResource reads are not set by a query scope here.
+     * Every job in this list is saved by the viewer by definition; applied
+     * state costs one extra lookup for the whole page rather than one per row.
+     *
+     * @param  Collection<int, SavedJob>  $savedJobs
+     */
+    protected function attachViewerFlags(Collection $savedJobs, User $viewer): void
+    {
+        $applicationStatuses = Application::query()
+            ->where('user_id', $viewer->id)
+            ->whereIn('cleaning_job_post_id', $savedJobs->pluck('cleaning_job_post_id'))
+            ->pluck('status', 'cleaning_job_post_id')
+            ->map(fn (ApplicationStatus $status): string => $status->value);
+
+        $savedJobs->each(function (SavedJob $savedJob) use ($applicationStatuses): void {
+            $savedJob->cleaningJobPost
+                ->setAttribute('is_saved_by_viewer', true)
+                ->setAttribute('has_applied_by_viewer', $applicationStatuses->has($savedJob->cleaning_job_post_id))
+                ->setAttribute('viewer_application_status_raw', $applicationStatuses->get($savedJob->cleaning_job_post_id));
+        });
     }
 
     /**

--- a/app/Http/Requests/DecideApplicationRequest.php
+++ b/app/Http/Requests/DecideApplicationRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DecideApplicationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('decide', $this->route('application'));
+    }
+
+    /**
+     * The message the employer sends the cleaner along with the decision. Fully
+     * optional — omitting it leaves decision_message null.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'message' => ['sometimes', 'nullable', 'string', 'max:2000'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreApplicationRequest.php
+++ b/app/Http/Requests/StoreApplicationRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Application;
+use App\Rules\MaxWords;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class StoreApplicationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('create', Application::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'cleaning_job_post_id' => ['required', 'integer', Rule::exists('cleaning_job_posts', 'id')],
+            'message' => ['sometimes', 'nullable', 'string', new MaxWords(101)],
+            'resume' => ['sometimes', 'nullable', 'file', File::types(['pdf'])->max(10 * 1024)],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateApplicationNoteRequest.php
+++ b/app/Http/Requests/UpdateApplicationNoteRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateApplicationNoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('decide', $this->route('application'));
+    }
+
+    /**
+     * The note must be present on every request but may be null, which is how
+     * the employer clears a note they saved earlier.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'note' => ['present', 'nullable', 'string', 'max:2000'],
+        ];
+    }
+}

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Application;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @mixin Application
+ */
+class ApplicationResource extends JsonResource
+{
+    /**
+     * The cleaner's own list embeds the job it targets; the employer's applicant
+     * list embeds a summary of the cleaner instead, plus the private note only
+     * the employer can see.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $viewer = $request->user();
+
+        return [
+            'id' => $this->id,
+            'status' => $this->status->value,
+            'message' => $this->message,
+            'resume_url' => $this->resume_path === null ? null : Storage::disk('public')->url($this->resume_path),
+            'job' => $this->when(
+                $viewer?->isCleaner() === true,
+                fn (): CleaningJobPostResource => new CleaningJobPostResource($this->cleaningJobPost),
+            ),
+            'cleaner' => $this->when(
+                $viewer?->isEmployer() === true,
+                fn (): array => $this->cleanerSummary(),
+            ),
+            // The employer writes this one *for* the cleaner, so unlike
+            // private_note it is readable by both sides.
+            'decision_message' => $this->decision_message,
+            'private_note' => $this->when($viewer?->isEmployer() === true, fn (): ?string => $this->private_note),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+
+    /**
+     * Rating and completed-job counts are placeholders until Phase 7 lands the
+     * rating system, matching CleanerProfileResource's own stubs.
+     *
+     * @return array{id: int, full_name: string, photo_url: string|null, rating_average: null, rating_count: int, completed_jobs_count: int}
+     */
+    protected function cleanerSummary(): array
+    {
+        $photoPath = $this->user->cleanerProfile?->photo_path;
+
+        return [
+            'id' => $this->user->id,
+            'full_name' => $this->user->name,
+            'photo_url' => $photoPath === null ? null : Storage::disk('public')->url($photoPath),
+            'rating_average' => null,
+            'rating_count' => 0,
+            'completed_jobs_count' => 0,
+        ];
+    }
+}

--- a/app/Http/Resources/CleaningJobPostResource.php
+++ b/app/Http/Resources/CleaningJobPostResource.php
@@ -50,8 +50,13 @@ class CleaningJobPostResource extends JsonResource
             'pay_amount' => $this->pay_amount === null ? null : (float) $this->pay_amount,
             'pay_currency' => $this->pay_currency,
             'media' => $this->mapMedia(),
-            'applications_count' => $this->when($isOwner, 0),
+            'applications_count' => $this->when($isOwner, fn (): int => (int) $this->getAttribute('applications_count')),
             'is_saved' => $this->when($viewerIsCleaner, fn (): bool => (bool) $this->getAttribute('is_saved_by_viewer')),
+            'has_applied' => $this->when($viewerIsCleaner, fn (): bool => (bool) $this->getAttribute('has_applied_by_viewer')),
+            'application_status' => $this->when(
+                $viewerIsCleaner && (bool) $this->getAttribute('has_applied_by_viewer'),
+                fn (): ?string => $this->getAttribute('viewer_application_status_raw'),
+            ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ApplicationStatus;
+use Database\Factories\ApplicationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $cleaning_job_post_id
+ * @property int $user_id
+ * @property ApplicationStatus $status
+ * @property string|null $message
+ * @property string|null $resume_path
+ * @property string|null $private_note
+ * @property string|null $decision_message
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ * @property-read CleaningJobPost $cleaningJobPost
+ */
+#[Fillable([
+    'cleaning_job_post_id',
+    'user_id',
+    'message',
+    'status',
+    'decision_message',
+])]
+class Application extends Model
+{
+    /** @use HasFactory<ApplicationFactory> */
+    use HasFactory;
+
+    /**
+     * Mirror the database column default so a new instance has the correct
+     * status before it is saved.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'status' => 'pending',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => ApplicationStatus::class,
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<CleaningJobPost, $this>
+     */
+    public function cleaningJobPost(): BelongsTo
+    {
+        return $this->belongsTo(CleaningJobPost::class);
+    }
+}

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -119,6 +119,14 @@ class CleaningJobPost extends Model
     }
 
     /**
+     * @return HasMany<Application, $this>
+     */
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
+    }
+
+    /**
      * Expose whether the given viewer (a cleaner) has saved each post as the
      * `is_saved_by_viewer` attribute via a single existence subquery, so it
      * costs no extra query per row on list endpoints. A no-op for guests and
@@ -135,6 +143,31 @@ class CleaningJobPost extends Model
         $query->withExists(['savedJobs as is_saved_by_viewer' => function (Builder $subQuery) use ($viewer): void {
             $subQuery->where('user_id', $viewer->id);
         }]);
+    }
+
+    /**
+     * Expose whether the given viewer (a cleaner) has applied to each post, and
+     * the status of that application, as the `has_applied_by_viewer` and
+     * `viewer_application_status_raw` attributes. Same single-subquery approach
+     * as scopeWithViewerSaved, and a no-op for guests and non-cleaners. The MAX
+     * aggregate is safe because the unique (cleaning_job_post_id, user_id)
+     * constraint guarantees at most one matching row.
+     *
+     * @param  Builder<CleaningJobPost>  $query
+     */
+    public function scopeWithViewerApplication(Builder $query, ?User $viewer): void
+    {
+        if ($viewer === null || ! $viewer->isCleaner()) {
+            return;
+        }
+
+        $constrainToViewer = function (Builder $subQuery) use ($viewer): void {
+            $subQuery->where('user_id', $viewer->id);
+        };
+
+        $query
+            ->withExists(['applications as has_applied_by_viewer' => $constrainToViewer])
+            ->withMax(['applications as viewer_application_status_raw' => $constrainToViewer], 'status');
     }
 
     /**

--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+
+/**
+ * The admin bypasses every check via the Gate::before hook in
+ * AppServiceProvider. Applying is a cleaner-only feature; deciding on an
+ * application belongs to the employer who owns the job post.
+ */
+class ApplicationPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->isCleaner();
+    }
+
+    /**
+     * Applying is gated on the cleaner role alone. This is also what enforces
+     * "an employer cannot apply to their own job": roles are fixed and
+     * single-valued, so the employer who owns a post can never hold the cleaner
+     * role and never passes this check — an ownership special-case here would
+     * be unreachable.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isCleaner();
+    }
+
+    /**
+     * Both sides of an application may read it: the cleaner who submitted it
+     * and the employer who owns the job post.
+     */
+    public function view(User $user, Application $application): bool
+    {
+        return $user->id === $application->user_id
+            || $user->id === $application->cleaningJobPost->employer_id;
+    }
+
+    /**
+     * Only the applying cleaner may withdraw, and only while the employer has
+     * not decided yet.
+     */
+    public function withdraw(User $user, Application $application): bool
+    {
+        return $user->id === $application->user_id
+            && $application->status === ApplicationStatus::Pending;
+    }
+
+    /**
+     * Whether the user may see the applicant list of a job post. Invoked as
+     * Gate::authorize('viewApplicants', [Application::class, $post]) because the
+     * ability lives with applications but is checked against the job post; the
+     * leading class string is what routes the check to this policy rather than
+     * CleaningJobPostPolicy.
+     */
+    public function viewApplicants(User $user, CleaningJobPost $cleaningJobPost): bool
+    {
+        return $user->id === $cleaningJobPost->employer_id;
+    }
+
+    /**
+     * Accept, reject, and private notes all belong to the employer who owns the
+     * job post the application targets.
+     */
+    public function decide(User $user, Application $application): bool
+    {
+        return $user->id === $application->cleaningJobPost->employer_id;
+    }
+}

--- a/database/factories/ApplicationFactory.php
+++ b/database/factories/ApplicationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\UserRole;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Application>
+ */
+class ApplicationFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'cleaning_job_post_id' => CleaningJobPost::factory(),
+            'user_id' => User::factory()->state(['role' => UserRole::Cleaner]),
+            'status' => ApplicationStatus::Pending,
+            'message' => fake()->optional()->sentence(),
+            'resume_path' => null,
+            'private_note' => null,
+        ];
+    }
+
+    public function status(ApplicationStatus $status): static
+    {
+        return $this->state(fn (array $attributes) => ['status' => $status]);
+    }
+}

--- a/database/migrations/2026_08_02_023122_create_applications_table.php
+++ b/database/migrations/2026_08_02_023122_create_applications_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cleaning_job_post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('status')->default('pending');
+            $table->text('message')->nullable();
+            $table->string('resume_path')->nullable();
+            $table->text('private_note')->nullable();
+            // Unlike private_note, this one is written for the cleaner to read.
+            $table->text('decision_message')->nullable();
+            $table->timestamps();
+
+            // Withdrawing or being rejected only transitions the status, never
+            // deletes the row, so this constraint is what permanently blocks a
+            // second application to the same job.
+            $table->unique(['cleaning_job_post_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('applications');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\ApplicationController;
 use App\Http\Controllers\Api\V1\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Api\V1\Auth\LoginController;
 use App\Http\Controllers\Api\V1\Auth\NewPasswordController;
@@ -56,6 +57,11 @@ Route::prefix('v1')->group(function (): void {
         Route::post('saved-jobs', [SavedJobController::class, 'store']);
         Route::delete('saved-jobs/{cleaningJobPost}', [SavedJobController::class, 'destroy'])
             ->whereNumber('cleaningJobPost');
+
+        Route::get('applications', [ApplicationController::class, 'index']);
+        Route::post('applications', [ApplicationController::class, 'store']);
+        Route::delete('applications/{application}', [ApplicationController::class, 'destroy'])
+            ->whereNumber('application');
     });
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use App\Http\Controllers\Api\V1\CleaningJobPostController;
+use App\Http\Controllers\Api\V1\JobApplicantController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\PublicProfileController;
 use App\Http\Controllers\Api\V1\SavedJobController;
@@ -61,6 +62,19 @@ Route::prefix('v1')->group(function (): void {
         Route::get('applications', [ApplicationController::class, 'index']);
         Route::post('applications', [ApplicationController::class, 'store']);
         Route::delete('applications/{application}', [ApplicationController::class, 'destroy'])
+            ->whereNumber('application');
+
+        // `/detail` keeps the single-application read from colliding with the
+        // flat GET /applications collection above.
+        Route::get('cleaning-job-posts/{cleaningJobPost}/applications', [JobApplicantController::class, 'index'])
+            ->whereNumber('cleaningJobPost');
+        Route::get('applications/{application}/detail', [JobApplicantController::class, 'show'])
+            ->whereNumber('application');
+        Route::patch('applications/{application}/accept', [JobApplicantController::class, 'accept'])
+            ->whereNumber('application');
+        Route::patch('applications/{application}/reject', [JobApplicantController::class, 'reject'])
+            ->whereNumber('application');
+        Route::patch('applications/{application}/note', [JobApplicantController::class, 'note'])
             ->whereNumber('application');
     });
 

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -1,0 +1,566 @@
+<?php
+
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+
+test('a cleaner can apply to an open published job with a message and a resume', function () {
+    Storage::fake('public');
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', [
+        'cleaning_job_post_id' => $post->id,
+        'message' => 'I have five years of hotel housekeeping experience.',
+        'resume' => UploadedFile::fake()->create('resume.pdf', 100, 'application/pdf'),
+    ])
+        ->assertCreated()
+        ->assertJsonPath('status', 'pending')
+        ->assertJsonPath('job.id', $post->id)
+        ->assertJsonPath('message', 'I have five years of hotel housekeeping experience.');
+
+    $application = Application::sole();
+    expect($application->user_id)->toBe($cleaner->id);
+    expect($application->cleaning_job_post_id)->toBe($post->id);
+    expect($application->status)->toBe(ApplicationStatus::Pending);
+    Storage::disk('public')->assertExists($application->resume_path);
+});
+
+test('a cleaner can apply without a message or a resume', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])
+        ->assertCreated()
+        ->assertJsonPath('message', null)
+        ->assertJsonPath('resume_url', null);
+});
+
+test('a cleaner cannot apply to the same job twice', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+
+    expect(Application::where('cleaning_job_post_id', $post->id)->count())->toBe(1);
+});
+
+test('a withdrawn or rejected application still blocks re-applying', function (ApplicationStatus $status) {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->status($status)->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+
+    expect(Application::where('cleaning_job_post_id', $post->id)->count())->toBe(1);
+})->with([ApplicationStatus::Withdrawn, ApplicationStatus::Rejected]);
+
+test('the duplicate and closed-job rejections are told apart by their message', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $openPost = CleaningJobPost::factory()->create();
+    $closedPost = CleaningJobPost::factory()->status(JobPostStatus::Closed)->create();
+    Application::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $openPost->id]);
+    Sanctum::actingAs($cleaner);
+
+    $duplicate = $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $openPost->id])
+        ->assertStatus(422)
+        ->json('errors.cleaning_job_post_id.0');
+
+    $closed = $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $closedPost->id])
+        ->assertStatus(422)
+        ->json('errors.cleaning_job_post_id.0');
+
+    expect($duplicate)->toBe('You have already applied to this job.');
+    expect($closed)->toBe('This job is no longer accepting applications.');
+});
+
+test('a cleaner cannot apply to a job that is not open and published', function (string $state) {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = $state === 'draft'
+        ? CleaningJobPost::factory()->draft()->create()
+        : CleaningJobPost::factory()->status(JobPostStatus::from($state))->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('cleaning_job_post_id');
+
+    $this->assertDatabaseCount('applications', 0);
+})->with(['draft', 'closed', 'completed', 'removed']);
+
+test('an employer cannot apply, which is what blocks applying to your own job', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    Sanctum::actingAs($employer);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])
+        ->assertForbidden();
+
+    $this->assertDatabaseCount('applications', 0);
+});
+
+test('a message longer than 101 words is rejected', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', [
+        'cleaning_job_post_id' => $post->id,
+        'message' => implode(' ', array_fill(0, 102, 'word')),
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('message');
+});
+
+test('a resume that is not a pdf is rejected', function () {
+    Storage::fake('public');
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', [
+        'cleaning_job_post_id' => $post->id,
+        'resume' => UploadedFile::fake()->image('resume.jpg'),
+    ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('resume');
+
+    $this->assertDatabaseCount('applications', 0);
+});
+
+test('a cleaner can withdraw a pending application', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $application = Application::factory()->create(['user_id' => $cleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/applications/{$application->id}")->assertOk();
+
+    // The row survives the withdrawal so the unique constraint keeps blocking
+    // a re-apply.
+    expect($application->refresh()->status)->toBe(ApplicationStatus::Withdrawn);
+});
+
+test('a cleaner cannot withdraw an application that is no longer pending', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $application = Application::factory()->status(ApplicationStatus::Accepted)->create(['user_id' => $cleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/applications/{$application->id}")->assertForbidden();
+
+    expect($application->refresh()->status)->toBe(ApplicationStatus::Accepted);
+});
+
+test('a cleaner cannot withdraw someone else application', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $application = Application::factory()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/applications/{$application->id}")->assertForbidden();
+});
+
+test('the applications list only returns the cleaner own applications', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    Application::factory()->count(2)->create(['user_id' => $cleaner->id]);
+    Application::factory()->count(3)->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/applications')
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonStructure(['data' => [['id', 'status', 'message', 'job' => ['id', 'title', 'status']]], 'links', 'meta']);
+});
+
+test('the applications list can be filtered to each status tab', function (ApplicationStatus $status) {
+    $cleaner = User::factory()->cleaner()->create();
+
+    foreach (ApplicationStatus::cases() as $case) {
+        Application::factory()->status($case)->create(['user_id' => $cleaner->id]);
+    }
+
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson("/api/v1/applications?status={$status->value}")
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', $status->value);
+})->with(ApplicationStatus::cases());
+
+test('an employer can list the applicants of their own job post', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    Application::factory()->count(2)->create(['cleaning_job_post_id' => $post->id]);
+    Application::factory()->count(3)->create();
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}/applications")
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonStructure(['data' => [['id', 'status', 'cleaner' => ['id', 'full_name', 'rating_average']]]]);
+});
+
+test('an employer cannot list the applicants of another employer job post', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}/applications")->assertForbidden();
+});
+
+test('a withdrawn applicant drops out of the employer applicant list but is still counted', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $active = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Application::factory()->status(ApplicationStatus::Withdrawn)->count(2)->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $response = $this->getJson("/api/v1/cleaning-job-posts/{$post->id}/applications")
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $active->id)
+        ->assertJsonPath('meta.withdrawn_count', 2);
+
+    // The extra meta key must not clobber the pagination meta it merges into.
+    expect($response->json('meta.total'))->toBe(1);
+    expect($response->json('meta.current_page'))->toBe(1);
+    expect($response->json('meta.per_page'))->toBe(15);
+});
+
+test('withdrawn_count is zero when no applicant has withdrawn', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}/applications")
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('meta.withdrawn_count', 0);
+});
+
+test('a cleaner still sees their own withdrawn application in their own list', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $withdrawn = Application::factory()->status(ApplicationStatus::Withdrawn)->create(['user_id' => $cleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/applications')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $withdrawn->id);
+
+    $this->getJson('/api/v1/applications?status=withdrawn')
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+});
+
+test('a single application is readable by both the owning cleaner and the owning employer', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+
+    Sanctum::actingAs($application->user);
+    $this->getJson("/api/v1/applications/{$application->id}/detail")
+        ->assertOk()
+        ->assertJsonPath('id', $application->id);
+
+    Sanctum::actingAs($employer);
+    $this->getJson("/api/v1/applications/{$application->id}/detail")
+        ->assertOk()
+        ->assertJsonPath('id', $application->id);
+});
+
+test('a single application is not readable by an unrelated user', function (string $role) {
+    $application = Application::factory()->create();
+    Sanctum::actingAs(User::factory()->{$role}()->create());
+
+    $this->getJson("/api/v1/applications/{$application->id}/detail")->assertForbidden();
+})->with(['cleaner', 'employer', 'moderator']);
+
+test('an employer can accept and reject applicants on their own job post', function (string $action, ApplicationStatus $expected) {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/{$action}")
+        ->assertOk()
+        ->assertJsonPath('status', $expected->value);
+
+    expect($application->refresh()->status)->toBe($expected);
+})->with([
+    ['accept', ApplicationStatus::Accepted],
+    ['reject', ApplicationStatus::Rejected],
+]);
+
+test('an already decided application cannot be decided again', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->status(ApplicationStatus::Accepted)->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/reject")
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('status');
+
+    expect($application->refresh()->status)->toBe(ApplicationStatus::Accepted);
+});
+
+test('an employer cannot decide on another employer applicants', function (string $action) {
+    $application = Application::factory()->create();
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->patchJson("/api/v1/applications/{$application->id}/{$action}")->assertForbidden();
+
+    expect($application->refresh()->status)->toBe(ApplicationStatus::Pending);
+})->with(['accept', 'reject']);
+
+test('a cleaner cannot decide on their own application', function () {
+    $application = Application::factory()->create();
+    Sanctum::actingAs($application->user);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/accept")->assertForbidden();
+});
+
+test('an employer can send the cleaner a message when deciding', function (string $action, ApplicationStatus $expected) {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/{$action}", ['message' => 'See you Monday at 8am.'])
+        ->assertOk()
+        ->assertJsonPath('status', $expected->value)
+        ->assertJsonPath('decision_message', 'See you Monday at 8am.');
+
+    expect($application->refresh()->decision_message)->toBe('See you Monday at 8am.');
+})->with([
+    ['accept', ApplicationStatus::Accepted],
+    ['reject', ApplicationStatus::Rejected],
+]);
+
+test('deciding without a message leaves the decision message null', function (string $action) {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/{$action}")
+        ->assertOk()
+        ->assertJsonPath('decision_message', null);
+
+    expect($application->refresh()->decision_message)->toBeNull();
+})->with(['accept', 'reject']);
+
+test('a decision message longer than 2000 characters is rejected', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/accept", ['message' => str_repeat('a', 2001)])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('message');
+
+    expect($application->refresh()->status)->toBe(ApplicationStatus::Pending);
+});
+
+test('the decision message is readable by both sides, unlike the private note', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/accept", ['message' => 'Welcome aboard.'])->assertOk();
+    $this->patchJson("/api/v1/applications/{$application->id}/note", ['note' => 'Strong hotel background.'])
+        ->assertOk()
+        ->assertJsonPath('decision_message', 'Welcome aboard.')
+        ->assertJsonPath('private_note', 'Strong hotel background.');
+
+    Sanctum::actingAs($application->user);
+    $this->getJson("/api/v1/applications/{$application->id}/detail")
+        ->assertOk()
+        ->assertJsonPath('decision_message', 'Welcome aboard.')
+        ->assertJsonMissingPath('private_note');
+
+    Sanctum::actingAs($employer);
+    $this->getJson("/api/v1/applications/{$application->id}/detail")
+        ->assertOk()
+        ->assertJsonPath('decision_message', 'Welcome aboard.')
+        ->assertJsonPath('private_note', 'Strong hotel background.');
+});
+
+test('the owning employer can set a private note that the cleaner never sees', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/note", ['note' => 'Strong hotel background.'])
+        ->assertOk()
+        ->assertJsonPath('private_note', 'Strong hotel background.');
+
+    Sanctum::actingAs($application->user);
+    $this->getJson("/api/v1/applications/{$application->id}/detail")
+        ->assertOk()
+        ->assertJsonMissingPath('private_note');
+});
+
+test('another employer cannot set a private note', function () {
+    $application = Application::factory()->create();
+    Sanctum::actingAs(User::factory()->employer()->create());
+
+    $this->patchJson("/api/v1/applications/{$application->id}/note", ['note' => 'Nope.'])->assertForbidden();
+});
+
+test('a guest cannot use any application endpoint', function () {
+    $post = CleaningJobPost::factory()->create();
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+
+    $this->getJson('/api/v1/applications')->assertUnauthorized();
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])->assertUnauthorized();
+    $this->deleteJson("/api/v1/applications/{$application->id}")->assertUnauthorized();
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}/applications")->assertUnauthorized();
+    $this->getJson("/api/v1/applications/{$application->id}/detail")->assertUnauthorized();
+    $this->patchJson("/api/v1/applications/{$application->id}/accept")->assertUnauthorized();
+    $this->patchJson("/api/v1/applications/{$application->id}/reject")->assertUnauthorized();
+    $this->patchJson("/api/v1/applications/{$application->id}/note", ['note' => 'x'])->assertUnauthorized();
+});
+
+test('non-cleaner roles cannot use the cleaner application endpoints', function (string $role) {
+    $post = CleaningJobPost::factory()->create();
+    Sanctum::actingAs(User::factory()->{$role}()->create());
+
+    $this->getJson('/api/v1/applications')->assertForbidden();
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])->assertForbidden();
+})->with(['employer', 'moderator']);
+
+test('the browse feed flags which jobs the cleaner has applied to and with what status', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $appliedPost = CleaningJobPost::factory()->create();
+    $untouchedPost = CleaningJobPost::factory()->create();
+    Application::factory()->status(ApplicationStatus::Accepted)->create([
+        'user_id' => $cleaner->id,
+        'cleaning_job_post_id' => $appliedPost->id,
+    ]);
+    Sanctum::actingAs($cleaner);
+
+    $data = collect($this->getJson('/api/v1/cleaning-job-posts')->assertOk()->json('data'))->keyBy('id');
+
+    expect($data[$appliedPost->id]['has_applied'])->toBeTrue();
+    expect($data[$appliedPost->id]['application_status'])->toBe('accepted');
+    expect($data[$untouchedPost->id]['has_applied'])->toBeFalse();
+    expect($data[$untouchedPost->id])->not->toHaveKey('application_status');
+});
+
+test('a rejected or withdrawn application still reports has_applied on the job detail', function (ApplicationStatus $status) {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->status($status)->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonPath('has_applied', true)
+        ->assertJsonPath('application_status', $status->value);
+})->with([ApplicationStatus::Rejected, ApplicationStatus::Withdrawn]);
+
+test('has_applied is omitted for guests and employers', function () {
+    $post = CleaningJobPost::factory()->create();
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('has_applied');
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('has_applied');
+});
+
+test('the saved jobs list and the applications list agree on the viewer flags', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->create(['user_id' => $cleaner->id, 'cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/saved-jobs', ['cleaning_job_post_id' => $post->id])
+        ->assertCreated()
+        ->assertJsonPath('job.is_saved', true)
+        ->assertJsonPath('job.has_applied', true)
+        ->assertJsonPath('job.application_status', 'pending');
+
+    $this->getJson('/api/v1/saved-jobs')
+        ->assertOk()
+        ->assertJsonPath('data.0.job.has_applied', true);
+
+    $this->getJson('/api/v1/applications')
+        ->assertOk()
+        ->assertJsonPath('data.0.job.is_saved', true)
+        ->assertJsonPath('data.0.job.has_applied', true);
+});
+
+test('the owning employer sees a real applications count on their job post', function () {
+    $employer = User::factory()->employer()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    Application::factory()->count(3)->create(['cleaning_job_post_id' => $post->id]);
+    Sanctum::actingAs($employer);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonPath('applications_count', 3);
+
+    $this->getJson('/api/v1/cleaning-job-posts/mine')
+        ->assertOk()
+        ->assertJsonPath('data.0.applications_count', 3);
+});
+
+test('applications_count is omitted for everyone but the owning employer', function () {
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('applications_count');
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+    $this->getJson("/api/v1/cleaning-job-posts/{$post->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('applications_count');
+});
+
+test('computing the application flags on the browse feed does not add a query per post', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    Sanctum::actingAs($cleaner);
+
+    CleaningJobPost::factory()->create();
+    DB::enableQueryLog();
+    $this->getJson('/api/v1/cleaning-job-posts')->assertOk();
+    $single = count(DB::getQueryLog());
+    DB::flushQueryLog();
+    DB::disableQueryLog();
+
+    // Add more posts with the log OFF so only request queries are counted.
+    CleaningJobPost::factory()->count(4)->create();
+
+    DB::enableQueryLog();
+    $this->getJson('/api/v1/cleaning-job-posts')->assertOk();
+    $many = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($many)->toBe($single);
+});


### PR DESCRIPTION
### Summary

This PR introduces the full job application lifecycle for the CleanHub platform. Cleaners can now apply to open published job posts (with an optional cover message and PDF résumé), withdraw a pending application, and track the status of every application they have submitted. Employers receive a companion set of endpoints to list, inspect, accept, reject, and privately annotate applications for the job posts they own. A single `ApplicationStatus` enum and a dedicated `ApplicationPolicy` keep the role boundaries crisp and consistent throughout.

---

#### What Changed

##### Database

- **Migration** — `create_applications_table`: new `applications` table with `cleaning_job_post_id`, `user_id`, `status` (default `pending`), `message`, `resume_path`, `private_note` (employer-only), and `decision_message` (visible to cleaner). A unique constraint on `(cleaning_job_post_id, user_id)` permanently blocks a second application even after withdrawal or rejection — the row is a status machine, never deleted.
- **Enum** — `ApplicationStatus`: `Pending | Accepted | Rejected | Withdrawn`.
- **Factory** — `ApplicationFactory` with a chainable `->status()` helper.

##### Model Layer

- **`Application` model** — `BelongsTo` User and CleaningJobPost, `status` cast to `ApplicationStatus`, default attribute set to `pending`.
- **`CleaningJobPost` model** — added `applications()` HasMany relation, `scopeWithViewerApplication()` query scope (mirrors `scopeWithViewerSaved`): attaches `has_applied_by_viewer` and `viewer_application_status_raw` as subquery attributes in a single round-trip.

##### Authorization

- **`ApplicationPolicy`**: `viewAny` / `create` (cleaner-only), `view` (own cleaner **or** owning employer), `withdraw` (own cleaner, status `pending` only), `viewApplicants` (owning employer, checked against the post), `decide` (owning employer).
- Role separation is structural: an employer can never pass the cleaner-role check, so no extra ownership guard is needed for the apply action.

##### API Endpoints

| Method | URI | Controller | Description |
|--------|-----|------------|-------------|
| `GET` | `/api/v1/applications` | `ApplicationController@index` | Cleaner's own application list (paginated, filterable by status) |
| `POST` | `/api/v1/applications` | `ApplicationController@store` | Submit an application (message + optional PDF résumé ≤ 10 MB, message ≤ 101 words) |
| `DELETE` | `/api/v1/applications/{application}` | `ApplicationController@destroy` | Withdraw a pending application (status → `withdrawn`, row kept) |
| `GET` | `/api/v1/cleaning-job-posts/{post}/applications` | `JobApplicantController@index` | Employer's applicant list for a post (withdrawn excluded, count surfaced in meta) |
| `GET` | `/api/v1/applications/{application}/detail` | `JobApplicantController@show` | Single-application read (both sides) |
| `PATCH` | `/api/v1/applications/{application}/accept` | `JobApplicantController@accept` | Accept a pending application |
| `PATCH` | `/api/v1/applications/{application}/reject` | `JobApplicantController@reject` | Reject a pending application |
| `PATCH` | `/api/v1/applications/{application}/note` | `JobApplicantController@note` | Set / clear employer's private note |

> `/detail` suffix keeps the single-application read from colliding with the flat `GET /applications` collection route.

##### Form Requests

| Request Class | Purpose |
|---|---|
| `StoreApplicationRequest` | `cleaning_job_post_id` (required, exists), `message` (nullable, ≤ 101 words), `resume` (nullable PDF ≤ 10 MB) |
| `DecideApplicationRequest` | `message` (nullable, ≤ 2 000 chars); authorize checks `decide` policy |
| `UpdateApplicationNoteRequest` | `note` (`present`, nullable, ≤ 2 000 chars); authorize checks `decide` policy |

##### Resources

- **`ApplicationResource`** — emits `status`, `message`, `resume_url`, `decision_message`, `job` (embedded `CleaningJobPostResource`), `cleaner` (summary sub-object with name + photo URL + rating stubs). `private_note` is conditionally included only when the viewer is an employer.
- **`CleaningJobPostResource`** — `applications_count` now resolves to a real aggregate (was hard-coded `0`). New cleaner-facing fields: `has_applied` (bool) and `application_status` (string | null, only emitted when `has_applied` is true).

##### Saved-Job Fix

`SavedJobController@index` now calls `scopeWithViewerApplication` alongside `scopeWithViewerSaved`, so the saved-jobs list also carries the cleaner's application status for each post.

##### Tests

`ApplicationTest.php` — 566-line feature test covering:
- Apply with and without message/résumé
- Duplicate-application block (including withdrawn/rejected re-apply)
- Closed / unpublished job rejection
- Withdrawal and idempotency
- Employer accept / reject / note flows
- Authorization matrix (guest, wrong role, wrong owner)
- `applications_count` accuracy on job post resource

---