### PR TITLE
Fix: Exclude applied jobs from cleaner feed and raise pagination defaults

### DIFF
--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -37,6 +37,7 @@ class ApplicationController extends Controller
 
         $validated = $request->validate([
             'status' => ['sometimes', Rule::enum(ApplicationStatus::class)],
+            'per_page' => $this->perPageRule(),
         ]);
 
         $applications = Application::query()
@@ -44,7 +45,7 @@ class ApplicationController extends Controller
             ->when(isset($validated['status']), fn (Builder $query) => $query->where('status', $validated['status']))
             ->with(['cleaningJobPost.employer', 'cleaningJobPost.category'])
             ->latest()
-            ->paginate(15);
+            ->paginate($validated['per_page'] ?? 50);
 
         $this->attachViewerFlags($applications->getCollection(), $request->user());
 

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -47,6 +47,7 @@ class CleaningJobPostController extends Controller
 
         $viewer = $request->user('sanctum');
         $canFilterByStatus = $viewer !== null && ! $viewer->isCleaner();
+        $isCleaner = $viewer !== null && $viewer->isCleaner();
 
         if (isset($validated['status']) && ! $canFilterByStatus) {
             throw ValidationException::withMessages([
@@ -72,6 +73,14 @@ class CleaningJobPostController extends Controller
             ->withCount('applications')
             ->withViewerSaved($viewer)
             ->withViewerApplication($viewer)
+            // A cleaner has already acted on a job they applied to, so it drops
+            // out of their feed. Their applications list is where they track it.
+            // A keyword search is exhaustive though: looking a job up by name is
+            // a deliberate act, so applied jobs stay findable there.
+            ->when(
+                $isCleaner && ! isset($validated['search']),
+                fn (Builder $q) => $q->whereDoesntHave('applications', fn (Builder $a) => $a->where('user_id', $viewer->id)),
+            )
             ->when(
                 isset($validated['search']),
                 fn (Builder $builder) => $builder->where(function (Builder $inner) use ($validated): void {

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -160,7 +160,8 @@ class CleaningJobPostController extends Controller
      * List a given employer's public job posts for their profile page: every
      * published post across open/reviewing/closed/completed. Drafts (not yet
      * public) and removed (hidden) posts are excluded. Any authenticated user
-     * may view this.
+     * may view this, but an employer looking at their own profile is served by
+     * mine() instead — so no owner-only data (applications_count) is loaded here.
      */
     public function forEmployer(Request $request, int $id): AnonymousResourceCollection
     {
@@ -173,7 +174,6 @@ class CleaningJobPostController extends Controller
             ->published()
             ->where('status', '!=', JobPostStatus::Removed->value)
             ->with(['employer', 'category'])
-            ->withCount('applications')
             ->withViewerSaved($request->user('sanctum'))
             ->withViewerApplication($request->user('sanctum'))
             ->latest()

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -42,7 +42,7 @@ class CleaningJobPostController extends Controller
             'schedule_date' => ['sometimes', 'date'],
             'status' => ['sometimes', Rule::enum(JobPostStatus::class)],
             'sort' => ['sometimes', Rule::in(['newest', 'soonest', 'top_employer'])],
-            'per_page' => ['sometimes', 'integer', 'min:1', 'max:50'],
+            'per_page' => $this->perPageRule(),
         ]);
 
         $viewer = $request->user('sanctum');
@@ -88,7 +88,7 @@ class CleaningJobPostController extends Controller
 
         $this->applySort($query, $validated['sort'] ?? 'newest');
 
-        $posts = $query->paginate($validated['per_page'] ?? 15)->withQueryString();
+        $posts = $query->paginate($validated['per_page'] ?? 50)->withQueryString();
 
         return CleaningJobPostResource::collection($posts);
     }
@@ -120,6 +120,7 @@ class CleaningJobPostController extends Controller
             'status' => ['sometimes', Rule::enum(JobPostStatus::class)],
             'schedule_date' => ['sometimes', 'date'],
             'sort' => ['sometimes', Rule::in(['newest', 'oldest', 'soonest'])],
+            'per_page' => $this->perPageRule(),
         ]);
 
         $query = CleaningJobPost::query()
@@ -143,7 +144,7 @@ class CleaningJobPostController extends Controller
             default => $query->orderByDesc('created_at'),
         };
 
-        return CleaningJobPostResource::collection($query->paginate(15));
+        return CleaningJobPostResource::collection($query->paginate($validated['per_page'] ?? 50));
     }
 
     /**
@@ -154,6 +155,8 @@ class CleaningJobPostController extends Controller
      */
     public function forEmployer(Request $request, int $id): AnonymousResourceCollection
     {
+        $validated = $request->validate(['per_page' => $this->perPageRule()]);
+
         $employer = User::where('role', UserRole::Employer)->findOrFail($id);
 
         $posts = CleaningJobPost::query()
@@ -165,7 +168,7 @@ class CleaningJobPostController extends Controller
             ->withViewerSaved($request->user('sanctum'))
             ->withViewerApplication($request->user('sanctum'))
             ->latest()
-            ->paginate(15);
+            ->paginate($validated['per_page'] ?? 50);
 
         return CleaningJobPostResource::collection($posts);
     }

--- a/app/Http/Controllers/Api/V1/JobApplicantController.php
+++ b/app/Http/Controllers/Api/V1/JobApplicantController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\UpdateApplicationNoteRequest;
 use App\Http\Resources\ApplicationResource;
 use App\Models\Application;
 use App\Models\CleaningJobPost;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
@@ -21,16 +22,18 @@ class JobApplicantController extends Controller
      * post, so the leading class string is what routes the check there instead
      * of to CleaningJobPostPolicy.
      */
-    public function index(CleaningJobPost $cleaningJobPost): AnonymousResourceCollection
+    public function index(Request $request, CleaningJobPost $cleaningJobPost): AnonymousResourceCollection
     {
         Gate::authorize('viewApplicants', [Application::class, $cleaningJobPost]);
+
+        $validated = $request->validate(['per_page' => $this->perPageRule()]);
 
         $applications = Application::query()
             ->where('cleaning_job_post_id', $cleaningJobPost->id)
             ->where('status', '!=', ApplicationStatus::Withdrawn)
             ->with(['user.cleanerProfile'])
             ->latest()
-            ->paginate(15);
+            ->paginate($validated['per_page'] ?? 50);
 
         // Applicants who withdrew drop out of the list the employer works
         // through, but the employer still gets to see how many there were.

--- a/app/Http/Controllers/Api/V1/SavedJobController.php
+++ b/app/Http/Controllers/Api/V1/SavedJobController.php
@@ -31,11 +31,13 @@ class SavedJobController extends Controller
     {
         Gate::authorize('viewAny', SavedJob::class);
 
+        $validated = $request->validate(['per_page' => $this->perPageRule()]);
+
         $saved = SavedJob::query()
             ->where('user_id', $request->user()->id)
             ->with(['cleaningJobPost.employer', 'cleaningJobPost.category'])
             ->latest()
-            ->paginate(15);
+            ->paginate($validated['per_page'] ?? 50);
 
         $this->attachViewerFlags($saved->getCollection(), $request->user());
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -4,5 +4,15 @@ namespace App\Http\Controllers;
 
 abstract class Controller
 {
-    //
+    /**
+     * Shared validation for the client-selectable page size on every paginated
+     * list endpoint. Out-of-range values are rejected rather than clamped, so a
+     * client always knows the page size it asked for is the one it got.
+     *
+     * @return array<int, string>
+     */
+    protected function perPageRule(): array
+    {
+        return ['sometimes', 'integer', 'min:50', 'max:200'];
+    }
 }

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -238,7 +238,7 @@ test('a withdrawn applicant drops out of the employer applicant list but is stil
     // The extra meta key must not clobber the pagination meta it merges into.
     expect($response->json('meta.total'))->toBe(1);
     expect($response->json('meta.current_page'))->toBe(1);
-    expect($response->json('meta.per_page'))->toBe(15);
+    expect($response->json('meta.per_page'))->toBe(50);
 });
 
 test('withdrawn_count is zero when no applicant has withdrawn', function () {

--- a/tests/Feature/ApplicationTest.php
+++ b/tests/Feature/ApplicationTest.php
@@ -449,17 +449,18 @@ test('non-cleaner roles cannot use the cleaner application endpoints', function 
     $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])->assertForbidden();
 })->with(['employer', 'moderator']);
 
-test('the browse feed flags which jobs the cleaner has applied to and with what status', function () {
+test('a job listing flags which jobs the cleaner has applied to and with what status', function () {
+    $employer = User::factory()->employer()->create();
     $cleaner = User::factory()->cleaner()->create();
-    $appliedPost = CleaningJobPost::factory()->create();
-    $untouchedPost = CleaningJobPost::factory()->create();
+    $appliedPost = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $untouchedPost = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
     Application::factory()->status(ApplicationStatus::Accepted)->create([
         'user_id' => $cleaner->id,
         'cleaning_job_post_id' => $appliedPost->id,
     ]);
     Sanctum::actingAs($cleaner);
 
-    $data = collect($this->getJson('/api/v1/cleaning-job-posts')->assertOk()->json('data'))->keyBy('id');
+    $data = collect($this->getJson("/api/v1/employers/{$employer->id}/cleaning-job-posts")->assertOk()->json('data'))->keyBy('id');
 
     expect($data[$appliedPost->id]['has_applied'])->toBeTrue();
     expect($data[$appliedPost->id]['application_status'])->toBe('accepted');
@@ -563,4 +564,67 @@ test('computing the application flags on the browse feed does not add a query pe
     DB::disableQueryLog();
 
     expect($many)->toBe($single);
+});
+
+test('a job the cleaner already applied to drops out of their browse feed', function () {
+    $applicant = User::factory()->cleaner()->create();
+    $appliedPost = CleaningJobPost::factory()->create();
+    $untouchedPost = CleaningJobPost::factory()->create();
+    Application::factory()->create([
+        'user_id' => $applicant->id,
+        'cleaning_job_post_id' => $appliedPost->id,
+    ]);
+
+    Sanctum::actingAs($applicant);
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $untouchedPost->id);
+
+    // The applied job is still tracked on the cleaner's own applications list.
+    $this->getJson('/api/v1/applications')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.job.id', $appliedPost->id);
+});
+
+test('a cleaner searching by keyword still finds a job they already applied to', function () {
+    $applicant = User::factory()->cleaner()->create();
+    $appliedPost = CleaningJobPost::factory()->create(['title' => 'Hotel Housekeeping Team']);
+    Application::factory()->create([
+        'user_id' => $applicant->id,
+        'cleaning_job_post_id' => $appliedPost->id,
+    ]);
+
+    Sanctum::actingAs($applicant);
+    $this->getJson('/api/v1/cleaning-job-posts?search=Housekeeping')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $appliedPost->id)
+        ->assertJsonPath('data.0.has_applied', true);
+});
+
+test('the applied-job exclusion is scoped to the cleaner who applied', function () {
+    $applicant = User::factory()->cleaner()->create();
+    $appliedPost = CleaningJobPost::factory()->create();
+    Application::factory()->create([
+        'user_id' => $applicant->id,
+        'cleaning_job_post_id' => $appliedPost->id,
+    ]);
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.id', $appliedPost->id);
+
+    Sanctum::actingAs(User::factory()->employer()->create());
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.id', $appliedPost->id);
+});
+
+test('a guest still sees a job that some cleaner has applied to', function () {
+    $post = CleaningJobPost::factory()->create();
+    Application::factory()->create(['cleaning_job_post_id' => $post->id]);
+
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()->assertJsonCount(1, 'data')->assertJsonPath('data.0.id', $post->id);
 });

--- a/tests/Feature/CleaningJobPostBrowseTest.php
+++ b/tests/Feature/CleaningJobPostBrowseTest.php
@@ -58,12 +58,28 @@ test('posts can be sorted by soonest schedule', function () {
 test('per_page controls pagination size', function () {
     CleaningJobPost::factory()->count(5)->create();
 
-    $this->getJson('/api/v1/cleaning-job-posts?per_page=2')
+    $this->getJson('/api/v1/cleaning-job-posts?per_page=200')
         ->assertOk()
-        ->assertJsonCount(2, 'data')
-        ->assertJsonPath('meta.per_page', 2)
+        ->assertJsonCount(5, 'data')
+        ->assertJsonPath('meta.per_page', 200)
         ->assertJsonPath('meta.total', 5);
 });
+
+test('the browse feed defaults to 50 posts per page', function () {
+    CleaningJobPost::factory()->count(51)->create();
+
+    $this->getJson('/api/v1/cleaning-job-posts')
+        ->assertOk()
+        ->assertJsonCount(50, 'data')
+        ->assertJsonPath('meta.per_page', 50)
+        ->assertJsonPath('meta.total', 51);
+});
+
+test('a per_page outside the allowed 50-200 range is rejected', function (int $perPage) {
+    $this->getJson("/api/v1/cleaning-job-posts?per_page={$perPage}")
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('per_page');
+})->with([49, 201]);
 
 test('an invalid sort value is rejected', function () {
     $this->getJson('/api/v1/cleaning-job-posts?sort=cheapest')

--- a/tests/Feature/SavedJobTest.php
+++ b/tests/Feature/SavedJobTest.php
@@ -211,3 +211,34 @@ test('computing is_saved on the browse feed does not add a query per post', func
 
     expect($many)->toBe($single);
 });
+
+test('the saved jobs list defaults to 50 per page', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $posts = CleaningJobPost::factory()->count(51)->create();
+    $posts->each(fn (CleaningJobPost $post) => SavedJob::factory()->create([
+        'user_id' => $cleaner->id,
+        'cleaning_job_post_id' => $post->id,
+    ]));
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/saved-jobs')
+        ->assertOk()
+        ->assertJsonCount(50, 'data')
+        ->assertJsonPath('meta.per_page', 50)
+        ->assertJsonPath('meta.total', 51);
+});
+
+test('the saved jobs list accepts per_page up to 200 and rejects anything outside 50-200', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/saved-jobs?per_page=200')
+        ->assertOk()
+        ->assertJsonPath('meta.per_page', 200);
+
+    $this->getJson('/api/v1/saved-jobs?per_page=201')
+        ->assertStatus(422)->assertJsonValidationErrors('per_page');
+
+    $this->getJson('/api/v1/saved-jobs?per_page=49')
+        ->assertStatus(422)->assertJsonValidationErrors('per_page');
+});


### PR DESCRIPTION
## Summary

Targeted backend fixes and quality-of-life improvements on top of `feat/applications`. No new database migrations or API endpoints are introduced — every change is a refinement of existing list endpoints, query scopes, and resource serialisation.

---

## What Changed

### Feed — applied jobs excluded from the cleaner browse feed

**Problem:** Once a cleaner applied to a job it kept appearing in their browse feed, creating noise alongside the dedicated My Applications list.

**Fix (`CleaningJobPostController@index`):** A conditional `whereDoesntHave` scope is applied when the viewer is an authenticated cleaner **and** no keyword search is active. Keyword searches remain exhaustive by design — looking a job up by name is a deliberate act, so applied jobs stay findable there.

```php
->when(
    $isCleaner && ! isset($validated['search']),
    fn (Builder $q) => $q->whereDoesntHave(
        'applications',
        fn (Builder $a) => $a->where('user_id', $viewer->id)
    ),
)
```

---

### Pagination — raised defaults and enforced 50–200 range

**Problem:** All list endpoints defaulted to 15 results per page. The previous cap of 50 was also too restrictive for clients that want a fuller result set in one request.

**Fix:** A shared `perPageRule()` method is added to the base `Controller` class. It enforces `min:50, max:200` and returns a **422 validation error** (rather than silently clamping) if the value is out of range. All paginated endpoints adopt it:

| Endpoint | Old default | New default | New max |
|---|---|---|---|
| `GET /api/v1/cleaning-job-posts` | 15 | **50** | 200 |
| `GET /api/v1/cleaning-job-posts` (mine) | 15 | **50** | 200 |
| `GET /api/v1/employers/{id}/cleaning-job-posts` | 15 | **50** | 200 |
| `GET /api/v1/applications` | 15 | **50** | 200 |
| `GET /api/v1/cleaning-job-posts/{id}/applicants` | 15 | **50** | 200 |
| `GET /api/v1/saved-jobs` | 15 | **50** | 200 |

---

### Public employer listing — `applications_count` removed

**Problem:** The public `GET /employers/{id}/cleaning-job-posts` endpoint was loading `withCount('applications')`, leaking aggregated applicant data to any authenticated viewer.

**Fix:** `withCount('applications')` is removed from `forEmployer()`. The private `mine()` endpoint (employer-only) retains full applicant data. The docblock is updated to document this boundary explicitly.

---

## Files Changed

| File | Change |
|---|---|
| `app/Http/Controllers/Controller.php` | Added shared `perPageRule()` helper |
| `app/Http/Controllers/Api/V1/CleaningJobPostController.php` | Applied-job exclusion scope; `perPageRule()` on `index`, `mine`, `forEmployer`; default 15 → 50; removed `withCount('applications')` from `forEmployer` |
| `app/Http/Controllers/Api/V1/ApplicationController.php` | `perPageRule()` on `index`; default 15 → 50 |
| `app/Http/Controllers/Api/V1/JobApplicantController.php` | `perPageRule()` on `index`; default 15 → 50 |
| `app/Http/Controllers/Api/V1/SavedJobController.php` | `perPageRule()` on `index`; default 15 → 50 |
| `tests/Feature/CleaningJobPostBrowseTest.php` | Tests for new default (50) and valid range (50–200) |
| `tests/Feature/ApplicationTest.php` | 4 new cases for applied-job exclusion; updated per_page assertion (15 → 50) |
| `tests/Feature/SavedJobTest.php` | Tests for new default and range validation |

---

## Testing

```bash
php artisan test --filter=CleaningJobPostBrowseTest
php artisan test --filter=ApplicationTest
php artisan test --filter=SavedJobTest
```

Key cases covered:

- Applied job drops out of the cleaner's browse feed
- Keyword search still returns a job the cleaner has applied to
- Exclusion is scoped to the cleaner who applied (other cleaners, employers, and guests still see it)
- Browse feed defaults to 50 per page; `per_page` outside 50–200 returns 422
- Saved-jobs list defaults to 50 per page; range validation enforced
