### PR TITLE
Docs: Cover job posts, profiles, saved jobs, applications, and calendar

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,10 +5,6 @@ described here, this document is the source of truth — the frontend and any ot
 client should map to what is written here rather than re-documenting the wire
 format.
 
-> This file grows as the API grows. It currently covers authentication and
-> account endpoints; later rounds append new sections (jobs, applications,
-> ratings, etc.) in the same format.
-
 ---
 
 ## Conventions
@@ -73,16 +69,74 @@ email-verification link).
   { "message": "Unauthenticated." }
   ```
 
-- **403 Forbidden** — a signed-link check failed (email verification only).
+- **403 Forbidden** — a signed-link check failed (email verification only), or a
+  policy denied the action (e.g. a non-owner trying to change a job post, an
+  employer calling an apply endpoint).
 
   ```json
-  { "message": "Invalid signature." }
+  { "message": "This action is unauthorized." }
+  ```
+
+- **404 Not Found** — the referenced record doesn't exist, or exists but is
+  scoped away from the caller (e.g. one employer trying to unsave another
+  cleaner's saved-job row resolves to a 404, not a 403, so cross-account rows
+  are indistinguishable from rows that were never there).
+
+- **409 Conflict** — the request is well-formed and the fields are individually
+  valid, but accepting it would clash with something else the caller already
+  did. The one endpoint that returns this today is applying to a job whose
+  schedule overlaps a job the caller is already accepted for — see
+  [Applications](#applications) below. Shaped exactly like a `422`
+  (`{ message, errors }`), just with a different status code, so it goes through
+  the same field-error handling on the client while still being distinguishable
+  from an ordinary validation failure.
+
+  ```json
+  {
+    "message": "This job's schedule conflicts with a job you're already accepted for.",
+    "errors": {
+      "cleaning_job_post_id": ["This job's schedule conflicts with a job you're already accepted for."]
+    }
+  }
   ```
 
 In local development (`APP_DEBUG=true`), non-validation error responses
 (`401`/`403`/`404`/`5xx`) also include `exception`, `file`, `line`, and `trace`
 fields for debugging; production returns only `message`. Validation errors
-(`422`) are identical in both environments — always just `message` and `errors`.
+(`422`/`409`) are identical in both environments — always just `message` and
+`errors`.
+
+### Pagination
+
+Every list endpoint that returns more rows than fit on one screen accepts an
+optional `per_page` query parameter and returns Laravel's standard paginator
+envelope:
+
+```json
+{
+  "data": [ /* the rows for this page */ ],
+  "links": { "first": "...", "last": "...", "prev": null, "next": "..." },
+  "meta": {
+    "current_page": 1, "from": 1, "to": 50, "last_page": 3, "total": 120,
+    "path": "http://localhost:8000/api/v1/cleaning-job-posts", "per_page": 50,
+    "links": [ /* per-page-number pagination links, for building page buttons */ ]
+  }
+}
+```
+
+- `per_page` accepts an integer from **50 to 200**. A page is never smaller than
+  50 by design — the UI this API serves always wants enough rows to fill a feed
+  or a table without a second round trip for a "load more" click. Anything
+  outside that range is a `422` on the `per_page` field, not silently clamped —
+  a caller should always know the size it asked for is the size it got.
+- Omitting `per_page` defaults to `50`.
+- **Two endpoints are the exception**: `GET /cleaning-job-categories` and
+  `GET /calendar` return every matching row as a bare JSON array, with no
+  `data`/`links`/`meta` wrapper at all and no pagination. Both return a small,
+  bounded set the caller always wants in full — the whole category list to
+  populate a dropdown, or a whole calendar month's worth of accepted/completed
+  jobs — so paginating them would only get in the way of the one request that
+  actually needs them.
 
 ### Roles
 
@@ -133,6 +187,30 @@ default policy via `Password::defaults()`, and always require a matching
 | `GET /api/v1/auth/verify-email/{id}/{hash}`          | Signed link   | Mark an account's email verified.                   |
 | `POST /api/v1/auth/email/verification-notification`  | Bearer token  | Resend the verification email.                      |
 | `GET /api/v1/user`                                   | Bearer token  | Return the authenticated user.                      |
+| `GET /api/v1/cleaning-job-categories`                | Public        | List the active cleaning categories.                |
+| `GET /api/v1/cleaning-job-posts`                     | Public        | Browse published job posts, filtered/sorted/paginated. |
+| `GET /api/v1/cleaning-job-posts/{id}`                | Public        | View one job post.                                  |
+| `GET /api/v1/cleaning-job-posts/mine`                | Bearer token  | An employer's own job posts, any status.            |
+| `POST /api/v1/cleaning-job-posts`                    | Bearer token  | Post a new job (employer).                          |
+| `PATCH /api/v1/cleaning-job-posts/{id}`              | Bearer token  | Edit a draft, or advance a published post's status. |
+| `DELETE /api/v1/cleaning-job-posts/{id}`             | Bearer token  | Delete a job post (admin only).                     |
+| `GET /api/v1/employers/{id}/cleaning-job-posts`      | Bearer token  | One employer's published job posts, for their public profile. |
+| `GET /api/v1/profile`                                | Bearer token  | The authenticated user's own profile.               |
+| `PATCH /api/v1/profile`                              | Bearer token  | Update the authenticated user's own profile.        |
+| `GET /api/v1/cleaners/{id}`                          | Bearer token  | A cleaner's public profile.                         |
+| `GET /api/v1/employers/{id}`                         | Bearer token  | An employer's public profile.                       |
+| `GET /api/v1/saved-jobs`                             | Bearer token  | A cleaner's saved jobs.                             |
+| `POST /api/v1/saved-jobs`                            | Bearer token  | Save a job (cleaner).                               |
+| `DELETE /api/v1/saved-jobs/{jobId}`                  | Bearer token  | Unsave a job (cleaner).                             |
+| `GET /api/v1/applications`                           | Bearer token  | A cleaner's own applications, filterable by status. |
+| `POST /api/v1/applications`                          | Bearer token  | Apply to a job (cleaner).                           |
+| `DELETE /api/v1/applications/{id}`                   | Bearer token  | Withdraw a pending application (cleaner).           |
+| `GET /api/v1/cleaning-job-posts/{id}/applications`   | Bearer token  | The applicants of one of an employer's job posts.   |
+| `GET /api/v1/applications/{id}/detail`               | Bearer token  | One application, readable by either side of it.     |
+| `PATCH /api/v1/applications/{id}/accept`             | Bearer token  | Accept an applicant (employer).                     |
+| `PATCH /api/v1/applications/{id}/reject`             | Bearer token  | Reject an applicant (employer).                     |
+| `PATCH /api/v1/applications/{id}/note`               | Bearer token  | Set or clear a private note on an applicant (employer). |
+| `GET /api/v1/calendar`                               | Bearer token  | A cleaner's accepted/completed jobs.                |
 
 ### POST /api/v1/auth/register
 
@@ -435,3 +513,874 @@ trimmed `user` object in the auth responses.
 **Notes**
 
 - `password` and `remember_token` are never included.
+
+## Cleaning job categories
+
+The fixed list of work types a job post can belong to (residential, hotel,
+hospital, office, factory, event cleanup, and so on). An admin manages this
+list; every other account only ever reads it.
+
+### GET /api/v1/cleaning-job-categories
+
+**Auth:** Public. Lists every **active** category, alphabetically by name.
+Inactive categories are hidden entirely — a job post that already references one
+still displays fine (the category is embedded on the post itself), it just can't
+be picked for a new post.
+
+**Request body** — none.
+
+**Success response** — `200 OK` — a bare array, not the paginated envelope (see
+[Pagination](#pagination)):
+
+```json
+[
+  { "id": 8, "name": "Event Cleanup", "slug": "event-cleanup" },
+  { "id": 5, "name": "Factory", "slug": "factory" },
+  { "id": 3, "name": "Hospital", "slug": "hospital" },
+  { "id": 2, "name": "Hotel", "slug": "hotel" },
+  { "id": 4, "name": "Office", "slug": "office" },
+  { "id": 6, "name": "Public Space", "slug": "public-space" },
+  { "id": 7, "name": "Research Facility", "slug": "research-facility" },
+  { "id": 1, "name": "Residential", "slug": "residential" }
+]
+```
+
+**Notes**
+
+- `id` is what a job post's `cleaning_job_category_id` field references when
+  creating or filtering posts. `slug` exists for the frontend's own use (URLs,
+  CSS hooks) and carries no meaning server-side.
+
+## Cleaning job posts
+
+A job post is an employer's listing for cleaning work. Two independent axes
+describe where it stands, and they're never merged into one value:
+
+- **`visibility`** — `draft` or `published`. A draft is only visible to the
+  employer who owns it; publishing is what makes it appear to cleaners and
+  guests at all.
+- **`status`** — `open`, `reviewing`, `closed`, `completed`, or `removed`. This
+  is the lifecycle of the work itself, and only moves **forward**:
+  `open → reviewing → closed → completed`. A post is created `open` and stays
+  there until the employer advances it; `removed` is a separate branch reserved
+  for a moderator/admin hiding the post, never something an employer sets
+  directly, and a post can never move backward or skip a step once published.
+
+A published post's content (title, description, schedule, pay, and so on) is
+**locked** the moment it's published — the only field a `PATCH` can still touch
+is `status`. Content is only editable while the post is still a `draft`.
+
+### GET /api/v1/cleaning-job-posts
+
+**Auth:** Public, but the response shape depends on who's asking. This is the
+main browse/search feed: cleaners and guests scrolling through work, filtering
+by category, location, date, or a free-text search term.
+
+**Query parameters**
+
+| Param            | Type    | Notes                                                                 |
+| ---------------- | ------- | ---------------------------------------------------------------------- |
+| `search`         | string  | Matches against title, description, or the employer's name.          |
+| `category_id`    | integer | Must be an existing category id.                                     |
+| `country`        | string  | Exact match.                                                          |
+| `city`           | string  | Exact match.                                                          |
+| `schedule_date`  | date    | Exact match on the post's scheduled date.                            |
+| `status`         | string  | **Employer/moderator/admin only** — see below.                       |
+| `sort`           | string  | `newest` (default), `soonest` (earliest `schedule_date` first), or `top_employer` (falls back to `newest` until employer ratings exist). |
+| `per_page`       | integer | See [Pagination](#pagination).                                       |
+
+**Who sees what:**
+
+- **Guest or cleaner, no `search`** — only `open`, `published` posts. This is
+  the passive browse feed.
+- **Cleaner, browsing without a search term** — a job the cleaner has already
+  applied to drops out of this list entirely. It hasn't disappeared; it's just
+  that a passive feed isn't where a cleaner tracks something they've already
+  acted on — `GET /applications` is. The moment the cleaner is applying to
+  something new, not re-discovering something they've already dealt with, it
+  belongs off this list.
+- **Cleaner, with a `search` term** — every `published` post regardless of
+  status **except `removed`**, including ones the cleaner already applied to.
+  Typing a job's name is a deliberate, specific act, so search stays exhaustive
+  even where the passive feed narrows.
+- **Employer, moderator, or admin** — may additionally pass `status` to filter
+  by any status, including `removed`. Sending `status` as a cleaner or guest is
+  rejected with a `422` on the `status` field — that filter simply doesn't
+  exist for them.
+
+**Success response** — `200 OK`, paginated:
+
+```json
+{
+  "data": [
+    {
+      "id": 8,
+      "title": "Hotel Housekeeping Team",
+      "description": "Looking for a reliable housekeeping team for a 40-room boutique hotel. Daily turnover cleaning, linen changes, and restocking amenities.",
+      "requirements": "Must be comfortable with a fast-paced schedule.",
+      "qualifications": null,
+      "category": { "id": 2, "name": "Hotel" },
+      "employer": { "id": 8, "name": "Maria Employer", "rating_average": null, "rating_count": 0 },
+      "country": "Philippines",
+      "city": "Cebu City",
+      "address": null,
+      "schedule_date": "2026-09-15",
+      "start_time": "08:00",
+      "end_time": "16:00",
+      "cleaners_needed": 3,
+      "application_deadline": null,
+      "visibility": "published",
+      "status": "open",
+      "pay_amount": 1500,
+      "pay_currency": "PHP",
+      "media": [],
+      "is_saved": false,
+      "has_applied": false,
+      "created_at": "2026-08-07T02:08:16.000000Z",
+      "updated_at": "2026-08-07T02:08:16.000000Z"
+    }
+  ],
+  "links": { "first": "...", "last": "...", "prev": null, "next": null },
+  "meta": { "current_page": 1, "from": 1, "to": 5, "last_page": 1, "total": 5, "per_page": 50 }
+}
+```
+
+**Field notes**
+
+- `category` is always `{ id, name }` — never a bare id, and no `slug` (that's
+  a category-list-only field).
+- `employer.rating_average`/`rating_count` are placeholders (`null`/`0`) until
+  the rating system exists; the field names are already final so nothing shifts
+  under the frontend later.
+- `is_saved` and `has_applied` only appear for an authenticated **cleaner**
+  viewer — a guest or an employer never sees them (there's nothing to attach
+  them to). `has_applied: true` also brings along `application_status`, so the
+  card doesn't need a second request to know the cleaner is `pending`,
+  `accepted`, `rejected`, `withdrawn`, or `completed` on it.
+- `applications_count` appears only when the viewer is the post's own employer
+  — see [`applications_count` visibility](#applications_count-visibility)
+  below.
+
+**Error responses**
+
+- `422` — a cleaner or guest sent `status`:
+
+  ```json
+  {
+    "message": "Filtering job posts by status is not available for this account.",
+    "errors": { "status": ["Filtering job posts by status is not available for this account."] }
+  }
+  ```
+
+### GET /api/v1/cleaning-job-posts/{id}
+
+**Auth:** Public. A single post's full detail. Any published, non-`removed`
+post is visible to anyone; the owning employer can additionally view their own
+post in **any** state (including a still-`draft` one, or one that's been
+`removed`).
+
+**Success response** — `200 OK` — the same shape as one row of the browse feed
+above, plus `applications_count` when the viewer owns the post.
+
+**Error responses**
+
+- `404` — the post doesn't exist, or exists but isn't visible to this viewer
+  (a `draft`/`removed` post viewed by anyone but its owner looks identical to a
+  post that was never there).
+
+### GET /api/v1/cleaning-job-posts/mine
+
+**Auth:** Bearer token, employer only. The authenticated employer's own posts,
+in **every** visibility/status — this is the one place an employer's drafts and
+removed posts are listed.
+
+**Query parameters:** `search`, `status`, `schedule_date`, `sort`
+(`newest`/`oldest`/`soonest`), `per_page` — all scoped to this employer's own
+posts, so `status` here is never rejected the way it is on the public browse
+endpoint.
+
+**Success response** — `200 OK`, paginated, each row also carrying
+`applications_count` (the employer always owns what they're looking at here).
+
+### POST /api/v1/cleaning-job-posts
+
+**Auth:** Bearer token, employer only.
+
+**Request body**
+
+| Field                       | Type    | Required | Rules                                                  |
+| ---------------------------- | ------- | -------- | ------------------------------------------------------- |
+| `title`                      | string  | yes      | 101 words or fewer                                     |
+| `cleaning_job_category_id`   | integer | yes      | must be an active category                             |
+| `description`                | string  | yes      | —                                                       |
+| `requirements`               | string  | no       | max 5000 chars                                          |
+| `qualifications`             | string  | no       | max 5000 chars                                          |
+| `country`                    | string  | yes      | max 255                                                 |
+| `city`                       | string  | yes      | max 255                                                 |
+| `address`                    | string  | no       | max 255                                                 |
+| `schedule_date`              | date    | yes      | today or later                                          |
+| `start_time`, `end_time`     | string  | no       | `HH:MM`                                                 |
+| `cleaners_needed`            | integer | no       | 1–65535, defaults to 1                                  |
+| `application_deadline`       | date    | no       | on or before `schedule_date`                            |
+| `visibility`                 | string  | no       | `draft` (default) or `published`                        |
+| `pay_amount`                 | number  | no       | 0–99,999,999.99                                         |
+| `pay_currency`               | string  | no       | 3-letter code (display only — see root project notes on payment scope) |
+| `media`                      | array   | no       | up to 10 image files, 5 MB each                         |
+
+_Sample request body:_
+
+```json
+{
+  "title": "Hotel Housekeeping Team",
+  "cleaning_job_category_id": 2,
+  "description": "Looking for a reliable housekeeping team for a 40-room boutique hotel. Daily turnover cleaning, linen changes, and restocking amenities.",
+  "requirements": "Must be comfortable with a fast-paced schedule.",
+  "country": "Philippines",
+  "city": "Cebu City",
+  "schedule_date": "2026-09-15",
+  "start_time": "08:00",
+  "end_time": "16:00",
+  "cleaners_needed": 3,
+  "pay_amount": 1500,
+  "pay_currency": "PHP",
+  "visibility": "published"
+}
+```
+
+**Success response** — `201 Created` — the created post, `status` always
+`open` and `applications_count` always `0`.
+
+**Notes**
+
+- Leaving `visibility` unset creates a **draft**, invisible to anyone but the
+  owner. This is deliberate — an employer can build a post over several edits
+  before it goes live.
+
+### PATCH /api/v1/cleaning-job-posts/{id}
+
+**Auth:** Bearer token, must be the owning employer.
+
+Behaves completely differently depending on whether the post is still a draft:
+
+- **Still a draft** — every field from the create request is editable
+  (`sometimes`), plus `visibility` can move from `draft` to `published`.
+  `status` cannot be touched here at all (`422` if sent) — a draft is always
+  `open` under the hood until it's published.
+- **Already published** — every content field is locked (`422` if sent); the
+  **only** editable field is `status`, and only forward:
+  `open → reviewing → closed → completed`. Sending a status that moves
+  backward, skips the forward check, or targets `removed` (moderator/admin
+  only, done elsewhere) is rejected.
+
+**Request body (published post):**
+
+```json
+{ "status": "reviewing" }
+```
+
+**Success response** — `200 OK` — the updated post.
+
+**Error responses**
+
+- `422` — editing a locked field on a published post:
+
+  ```json
+  {
+    "message": "A published job post is locked; only its status can be changed.",
+    "errors": { "title": ["A published job post is locked; only its status can be changed."] }
+  }
+  ```
+
+- `422` — an out-of-order status transition:
+
+  ```json
+  {
+    "message": "A job post status can only move forward: open → reviewing → closed → completed.",
+    "errors": { "status": ["A job post status can only move forward: open → reviewing → closed → completed."] }
+  }
+  ```
+
+### DELETE /api/v1/cleaning-job-posts/{id}
+
+**Auth:** Bearer token, **admin only** — not even the owning employer can
+delete their own post. An employer who wants a post gone moves it forward
+through `status` instead (`closed`/`completed`); an admin removing a post is a
+moderation action, not a routine one.
+
+**Success response** — `200 OK`:
+
+```json
+{ "message": "Job post deleted." }
+```
+
+**Error responses**
+
+- `403` — anyone other than the admin, including the owning employer:
+
+  ```json
+  { "message": "This action is unauthorized." }
+  ```
+
+### GET /api/v1/employers/{id}/cleaning-job-posts
+
+**Auth:** Bearer token (any authenticated role). An employer's public job
+history for their profile page: every **published**, non-`removed` post
+(`open`/`reviewing`/`closed`/`completed`), newest first. Drafts and removed
+posts never appear here even to the owning employer viewing their own id — an
+employer viewing their **own** history uses `GET /cleaning-job-posts/mine`
+instead, which is the only endpoint that also shows `applications_count` and
+drafts.
+
+**Success response** — `200 OK`, paginated, same row shape as the browse feed
+but without `applications_count` (only `mine` carries that field, since it's
+owner-only data and this endpoint is explicitly the one *other* people use to
+look at an employer).
+
+## Profiles
+
+Every cleaner and employer has exactly one profile row, created automatically
+the first time it's read or written — there's no separate "create profile"
+step. The two roles have entirely different field sets; a cleaner's profile and
+an employer's profile are never the same shape.
+
+### `applications_count` visibility
+
+Worth calling out once here since it recurs across job-post endpoints:
+`applications_count` is only ever present in the JSON when the viewer **is**
+the employer who owns that post. Every other viewer — a cleaner browsing, a
+guest, another employer looking at someone else's profile — simply doesn't get
+the field at all (not `null`, not `0` — absent). This is what keeps how many
+people applied to a job private to the poster.
+
+### GET /api/v1/profile
+
+**Auth:** Bearer token, cleaner or employer. Returns the caller's **own**
+profile, shaped by their role. The underlying row is created on first access if
+it doesn't exist yet, so this never 404s for a valid cleaner/employer account —
+a brand-new account just gets an all-`null` profile back.
+
+**Success response — cleaner** — `200 OK`:
+
+```json
+{
+  "id": 4,
+  "user_id": 9,
+  "full_name": "Jane Cleaner",
+  "email": "jane.cleaner@example.com",
+  "photo_url": null,
+  "bio": null,
+  "country": null,
+  "city": null,
+  "cleaning_categories": [],
+  "languages": [],
+  "documents": [],
+  "rating_average": null,
+  "rating_count": 0,
+  "completed_jobs_count": 0,
+  "created_at": "2026-08-07T02:09:58.000000Z",
+  "updated_at": "2026-08-07T02:09:58.000000Z"
+}
+```
+
+**Success response — employer** — `200 OK`:
+
+```json
+{
+  "id": 4,
+  "user_id": 8,
+  "full_name": "Maria Employer",
+  "email": "maria.employer@example.com",
+  "employer_type": null,
+  "contact_person_name": null,
+  "contact_person_contact": null,
+  "country": null,
+  "city": null,
+  "address": null,
+  "about": null,
+  "photo_url": null,
+  "documents": [],
+  "rating_average": null,
+  "rating_count": 0,
+  "posted_jobs_count": 0,
+  "completed_jobs_count": 0,
+  "created_at": "2026-08-07T02:09:58.000000Z",
+  "updated_at": "2026-08-07T02:09:58.000000Z"
+}
+```
+
+**Notes**
+
+- `email` only appears when the caller is viewing their **own** profile — see
+  [`GET /cleaners/{id}` / `GET /employers/{id}`](#get-apiv1cleanersid) below for
+  what a third party sees.
+- `rating_average`/`rating_count`/`posted_jobs_count`/`completed_jobs_count`
+  are placeholders until ratings exist, same as job posts' employer summary.
+
+### PATCH /api/v1/profile
+
+**Auth:** Bearer token, cleaner or employer. Sent as `multipart/form-data`
+(via `POST` with `_method=PATCH`, the standard Laravel override) whenever a
+`photo` or `documents` file is attached, or plain JSON otherwise. Only the
+fields present in the request are changed — this is a true partial update, not
+a full replace.
+
+**Cleaner fields**
+
+| Field                 | Type    | Notes                                                          |
+| ---------------------- | ------- | --------------------------------------------------------------- |
+| `photo`                | file    | image, max 5 MB. Replaces the existing photo.                  |
+| `bio`                  | string  | 101 words or fewer                                              |
+| `country`, `city`      | string  | max 255 each                                                    |
+| `languages`            | array   | array of strings                                                |
+| `cleaning_categories`  | array   | array of active category ids — **replaces** the whole set (this one field is a full sync, not a merge, unlike `documents` below) |
+| `documents`            | array   | PDF files, max 10 MB each — **appended** to the existing list, never replaces it |
+
+**Employer fields**
+
+| Field                          | Type   | Notes                    |
+| -------------------------------- | ------ | -------------------------- |
+| `photo`                          | file   | image, max 5 MB           |
+| `employer_type`                  | string | max 255                   |
+| `contact_person_name`            | string | max 255                   |
+| `contact_person_contact`         | string | max 255                   |
+| `country`, `city`, `address`     | string | max 255 each               |
+| `about`                          | string | max 5000                  |
+| `documents`                      | array  | PDF files, max 10 MB each, appended (same as cleaner) |
+
+_Sample request body (cleaner):_
+
+```json
+{
+  "bio": "Detail-oriented cleaner with hotel and residential experience.",
+  "country": "Philippines",
+  "city": "Cebu City",
+  "cleaning_categories": [1, 2],
+  "languages": ["English", "Cebuano"]
+}
+```
+
+**Success response** — `200 OK` — the full updated profile, same shape as `GET
+/profile`:
+
+```json
+{
+  "id": 4,
+  "user_id": 9,
+  "full_name": "Jane Cleaner",
+  "email": "jane.cleaner@example.com",
+  "photo_url": null,
+  "bio": "Detail-oriented cleaner with hotel and residential experience.",
+  "country": "Philippines",
+  "city": "Cebu City",
+  "cleaning_categories": [
+    { "id": 1, "name": "Residential", "slug": "residential" },
+    { "id": 2, "name": "Hotel", "slug": "hotel" }
+  ],
+  "languages": ["English", "Cebuano"],
+  "documents": [],
+  "rating_average": null,
+  "rating_count": 0,
+  "completed_jobs_count": 0,
+  "created_at": "2026-08-07T02:09:58.000000Z",
+  "updated_at": "2026-08-07T02:10:18.000000Z"
+}
+```
+
+### GET /api/v1/cleaners/{id}
+
+**Auth:** Bearer token (any authenticated role). A cleaner's public profile —
+the same shape as `GET /profile` for a cleaner, minus `email`. A cleaner who
+hasn't touched their profile yet still returns a valid (all-empty) object
+rather than a `404`.
+
+### GET /api/v1/employers/{id}
+
+**Auth:** Bearer token (any authenticated role). Same idea, for an employer's
+public profile.
+
+**Error responses (both)**
+
+- `404` — no user with that id and that role (a cleaner id looked up through
+  `/employers/{id}` also 404s — the two endpoints are role-scoped, not just id
+  lookups).
+
+## Saved jobs
+
+A cleaner's personal shortlist. Cleaner-only — an employer or moderator gets a
+`403` from every endpoint in this section.
+
+### GET /api/v1/saved-jobs
+
+**Auth:** Bearer token, cleaner only. The caller's saved jobs, newest-saved
+first, paginated. Each row embeds the **full**, **live** job post — if a saved
+job has since closed or filled, that's reflected here immediately, nothing is
+filtered out.
+
+**Success response** — `200 OK`, paginated:
+
+```json
+{
+  "data": [
+    {
+      "id": 4,
+      "saved_at": "2026-08-07T02:08:27.000000Z",
+      "job": { "id": 8, "title": "Hotel Housekeeping Team", "status": "open", "...": "full job post" }
+    }
+  ],
+  "links": { "...": "..." },
+  "meta": { "...": "..." }
+}
+```
+
+### POST /api/v1/saved-jobs
+
+**Auth:** Bearer token, cleaner only. Saves a job. The job must be `open` and
+`published` **at the moment of saving** — once saved, it stays on the list even
+if it later changes status (that's the point of the list: track something even
+after it moves on).
+
+**Request body**
+
+```json
+{ "cleaning_job_post_id": 8 }
+```
+
+**Success response** — `201 Created` — same row shape as one entry of the list
+above.
+
+**Error responses**
+
+- `422` — the job isn't currently open/published:
+
+  ```json
+  {
+    "message": "Only open, published jobs can be saved.",
+    "errors": { "cleaning_job_post_id": ["Only open, published jobs can be saved."] }
+  }
+  ```
+
+- `422` — already saved:
+
+  ```json
+  {
+    "message": "This job is already in your saved list.",
+    "errors": { "cleaning_job_post_id": ["This job is already in your saved list."] }
+  }
+  ```
+
+### DELETE /api/v1/saved-jobs/{jobId}
+
+**Auth:** Bearer token, cleaner only. Note the route parameter is the **job
+post's** id, not the saved-row's id — a job detail page can unsave without
+first knowing the id of the underlying saved-jobs row. The lookup is scoped to
+the caller's own rows, so trying to unsave a job never in the caller's own
+saved list — including one saved by a different cleaner — is a `404`, not a
+`403`; there's no way to tell "someone else's row" apart from "no such row" and
+there's no need to.
+
+**Success response** — `200 OK`:
+
+```json
+{ "message": "Job removed from saved list." }
+```
+
+## Applications
+
+An application is what connects one cleaner to one job post. A cleaner can
+apply to a job at most once, ever — the underlying table has a permanent
+unique constraint on (job post, cleaner), and it is **never deleted**, only
+moved through statuses. That's also what makes "withdraw" reversible-looking
+but not actually a fresh start: a withdrawn application still occupies that
+unique slot, so re-applying to the same job after withdrawing is rejected the
+same as any other duplicate.
+
+Status values: `pending` (the only status right after applying) → `accepted` /
+`rejected` (an employer's decision) → `completed` (set once the work is
+finished — see the root project notes on ratings being unlocked by this).
+`withdrawn` is a cleaner-initiated dead end reachable only from `pending`.
+
+### GET /api/v1/applications
+
+**Auth:** Bearer token, cleaner only. The caller's own applications, newest
+first, paginated, optionally narrowed to one status via `?status=`. Each row
+embeds the full job post it targets, live status included — an application to
+a job that has since closed still shows up here with that reflected.
+
+**Success response** — `200 OK`, paginated:
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "status": "accepted",
+      "message": "I have five years of hotel housekeeping experience and can lead a small team.",
+      "resume_url": null,
+      "job": { "id": 8, "title": "Hotel Housekeeping Team", "application_status": "accepted", "has_applied": true, "...": "full job post" },
+      "decision_message": "You are booked in — see you on site at 8am.",
+      "created_at": "2026-08-07T02:08:27.000000Z",
+      "updated_at": "2026-08-07T02:08:37.000000Z"
+    }
+  ],
+  "links": { "...": "..." },
+  "meta": { "...": "..." }
+}
+```
+
+### POST /api/v1/applications
+
+**Auth:** Bearer token, cleaner only — an employer calling this at all gets a
+`403` before any field is even looked at, because the roles are fixed and
+mutually exclusive: the person who owns a job post can never simultaneously
+hold the cleaner role needed to apply to it. That single role check is the
+entire enforcement of "an employer can't apply to their own job" — there's no
+separate ownership check anywhere, because there's no code path where it could
+ever fire.
+
+Sent as `multipart/form-data` when a `resume` file is attached, plain JSON
+otherwise.
+
+**Request body**
+
+| Field                     | Type    | Required | Rules                                  |
+| -------------------------- | ------- | -------- | ----------------------------------------- |
+| `cleaning_job_post_id`      | integer | yes      | must reference an existing post          |
+| `message`                   | string  | no       | 101 words or fewer                       |
+| `resume`                    | file    | no       | PDF only, max 10 MB                      |
+
+_Sample request body:_
+
+```json
+{
+  "cleaning_job_post_id": 8,
+  "message": "I have five years of hotel housekeeping experience and can lead a small team."
+}
+```
+
+**Success response** — `201 Created`:
+
+```json
+{
+  "id": 5,
+  "status": "pending",
+  "message": "I have five years of hotel housekeeping experience and can lead a small team.",
+  "resume_url": null,
+  "job": { "id": 8, "has_applied": true, "application_status": "pending", "...": "full job post" },
+  "decision_message": null,
+  "created_at": "2026-08-07T02:08:27.000000Z",
+  "updated_at": "2026-08-07T02:08:27.000000Z"
+}
+```
+
+Three different rejections can come back from this one endpoint, checked in
+this order — each is worth telling apart, since only the last one is a `409`:
+
+**Error responses**
+
+- `422` — the job is no longer open/published (closed, reviewing, completed,
+  removed, or still a draft):
+
+  ```json
+  {
+    "message": "This job is no longer accepting applications.",
+    "errors": { "cleaning_job_post_id": ["This job is no longer accepting applications."] }
+  }
+  ```
+
+- `422` — already applied (including a withdrawn or rejected prior
+  application — the unique slot is still occupied):
+
+  ```json
+  {
+    "message": "You have already applied to this job.",
+    "errors": { "cleaning_job_post_id": ["You have already applied to this job."] }
+  }
+  ```
+
+- `409` — the job's date and time window overlaps a job the cleaner is already
+  **accepted** for. A job missing a recorded start/end time is treated as
+  occupying its entire scheduled date, since there's no narrower window to
+  compare against — two same-day jobs where either one has no time set always
+  conflict.
+
+  ```json
+  {
+    "message": "This job's schedule conflicts with a job you're already accepted for.",
+    "errors": { "cleaning_job_post_id": ["This job's schedule conflicts with a job you're already accepted for."] }
+  }
+  ```
+
+- `403` — the caller is an employer, not a cleaner:
+
+  ```json
+  { "message": "This action is unauthorized." }
+  ```
+
+### DELETE /api/v1/applications/{id}
+
+**Auth:** Bearer token, must be the applying cleaner, and the application must
+still be `pending`. This is a status transition to `withdrawn`, not an actual
+row delete — the unique-constraint row has to survive so re-applying to the
+same job stays blocked afterward.
+
+**Success response** — `200 OK`:
+
+```json
+{ "message": "Application withdrawn." }
+```
+
+**Error responses**
+
+- `403` — not the applying cleaner, or the application has already moved past
+  `pending` (accepted/rejected/completed can't be withdrawn — the employer has
+  already acted).
+
+### GET /api/v1/cleaning-job-posts/{jobId}/applications
+
+**Auth:** Bearer token, must be the employer who owns the job post. The
+applicant list for one job post, newest first, paginated. A cleaner who
+**withdrew** is dropped from this list — the employer works through active
+applicants only — but the total number who withdrew is still surfaced in
+`meta.withdrawn_count`, so an employer knows the full picture without seeing
+withdrawn rows mixed into their queue.
+
+**Success response** — `200 OK`, paginated, each row shaped for the employer's
+side (a `cleaner` summary instead of the cleaner's own `job` embed, plus the
+employer-only `private_note`):
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "status": "pending",
+      "message": "I have five years of hotel housekeeping experience and can lead a small team.",
+      "resume_url": null,
+      "cleaner": {
+        "id": 9,
+        "full_name": "Jane Cleaner",
+        "photo_url": null,
+        "rating_average": null,
+        "rating_count": 0,
+        "completed_jobs_count": 0
+      },
+      "decision_message": null,
+      "private_note": null,
+      "created_at": "2026-08-07T02:08:27.000000Z",
+      "updated_at": "2026-08-07T02:08:27.000000Z"
+    }
+  ],
+  "links": { "...": "..." },
+  "meta": { "current_page": 1, "...": "...", "withdrawn_count": 0 }
+}
+```
+
+### GET /api/v1/applications/{id}/detail
+
+**Auth:** Bearer token — readable by **both** sides of the application: the
+cleaner who submitted it, and the employer who owns the targeted job post. No
+one else. The `/detail` suffix exists purely so this single-resource route
+doesn't collide with the flat `GET /applications` collection above it.
+
+**Success response** — `200 OK` — shaped per viewer exactly like the list
+endpoints above (a cleaner sees `job`, an employer sees `cleaner` +
+`private_note`).
+
+### PATCH /api/v1/applications/{id}/accept
+
+**Auth:** Bearer token, must be the employer who owns the targeted job post.
+Moves a still-`pending` application to `accepted`. This is the **only** action
+in the whole application that ever sets a row to `accepted` — and accepting is
+also the only thing that puts a job on the cleaner's calendar (there's no
+separate calendar table; `GET /calendar` just reads accepted/completed
+applications directly — see [Calendar](#calendar)).
+
+**Request body** — optional:
+
+```json
+{ "message": "You are booked in — see you on site at 8am." }
+```
+
+**Success response** — `200 OK` — the updated application, `decision_message`
+set to whatever was sent (or `null` if omitted). Unlike `private_note` below,
+`decision_message` is written **by** the employer **for** the cleaner, so both
+sides can read it.
+
+**Error responses**
+
+- `422` — the application isn't `pending` anymore (already decided, or the
+  cleaner withdrew it in the meantime):
+
+  ```json
+  {
+    "message": "This application has already been decided.",
+    "errors": { "status": ["This application has already been decided."] }
+  }
+  ```
+
+### PATCH /api/v1/applications/{id}/reject
+
+**Auth:** Same as accept. Identical shape and the same `422` for an
+already-decided application; the only difference is the resulting `status` is
+`rejected` instead of `accepted`.
+
+### PATCH /api/v1/applications/{id}/note
+
+**Auth:** Bearer token, must be the owning employer. Sets (or clears) a private
+note on the application — visible **only** to the employer who wrote it, never
+to the cleaner, unlike `decision_message` above. Can be called at any point in
+the application's lifecycle, not just while `pending`.
+
+**Request body** — `note` must be present but may be `null` (that's how a saved
+note gets cleared):
+
+```json
+{ "note": "Strong resume, follow up about availability for weekends." }
+```
+
+**Success response** — `200 OK` — the updated application, `private_note` set.
+
+## Calendar
+
+### GET /api/v1/calendar
+
+**Auth:** Bearer token, cleaner only. Every job the caller is currently
+`accepted` for, or has `completed`, sorted by schedule date — this is the whole
+feed a monthly calendar view needs, fetched in one request. Nothing else
+belongs here: `pending`/`rejected`/`withdrawn` applications never show up on a
+calendar, because nothing has actually been committed to yet.
+
+**Success response** — `200 OK` — a **bare array**, not the paginated envelope
+(see [Pagination](#pagination)) — same row shape as `GET /applications`:
+
+```json
+[
+  {
+    "id": 5,
+    "status": "accepted",
+    "message": "I have five years of hotel housekeeping experience and can lead a small team.",
+    "resume_url": null,
+    "job": {
+      "id": 8,
+      "title": "Hotel Housekeeping Team",
+      "schedule_date": "2026-09-15",
+      "start_time": "08:00",
+      "end_time": "16:00",
+      "country": "Philippines",
+      "city": "Cebu City",
+      "employer": { "id": 8, "name": "Maria Employer", "rating_average": null, "rating_count": 0 },
+      "application_status": "accepted",
+      "...": "full job post"
+    },
+    "decision_message": "You are booked in — see you on site at 8am.",
+    "created_at": "2026-08-07T02:08:27.000000Z",
+    "updated_at": "2026-08-07T02:08:37.000000Z"
+  }
+]
+```
+
+**Error responses**
+
+- `403` — the caller isn't a cleaner (an employer's own schedule isn't modeled
+  this way — they see their commitments through their job posts' applicant
+  lists instead).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,8 +4,8 @@ A practical map of the Laravel backend: **if you're looking for X, here's where
 it lives.** For the wire contract see [`api.md`](api.md); for how to run and
 verify things see [`testing.md`](testing.md).
 
-> This file grows as the codebase grows. It currently reflects the auth & roles
-> foundation; later rounds append rows to the tables below in place.
+> This file is updated as the codebase grows — new rows are appended to the
+> tables below in place rather than superseding them.
 
 ---
 
@@ -14,20 +14,20 @@ verify things see [`testing.md`](testing.md).
 | Folder / Path                          | Purpose                                                                                             | Example file                                             |
 | -------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | `routes/api.php`                       | Every endpoint, grouped under the `v1` (and `auth`) prefix. One line per route, no logic.           | `routes/api.php`                                         |
-| `app/Http/Controllers/Api/V1/`         | Thin HTTP handlers, namespaced by API version; auth controllers under `Auth/`. Delegate validation. | `app/Http/Controllers/Api/V1/Auth/LoginController.php`   |
-| `app/Http/Requests/`                   | Form Requests — one per write endpoint; hold `rules()` (validation) and `authorize()`.              | `app/Http/Requests/Auth/RegisterRequest.php`             |
-| `app/Http/Resources/`                  | API Resources defining the exact JSON for a model. Change the wire shape here, not in controllers.  | `app/Http/Resources/UserResource.php`                    |
-| `app/Models/`                          | Eloquent models: casts, relationships, role/verification helpers.                                   | `app/Models/User.php`                                    |
-| `app/Enums/`                           | Backed enums for fixed value sets.                                                                  | `app/Enums/UserRole.php`                                 |
-| `app/Policies/`                        | Per-model authorization policies (auto-discovered, no manual registration).                         | `app/Policies/UserPolicy.php`                            |
+| `app/Http/Controllers/Api/V1/`         | Thin HTTP handlers, namespaced by API version; auth controllers under `Auth/`. Delegate validation. | `app/Http/Controllers/Api/V1/CleaningJobPostController.php` |
+| `app/Http/Requests/`                   | Form Requests — one per write endpoint; hold `rules()` (validation) and `authorize()`.              | `app/Http/Requests/StoreApplicationRequest.php`          |
+| `app/Http/Resources/`                  | API Resources defining the exact JSON for a model. Change the wire shape here, not in controllers.  | `app/Http/Resources/CleaningJobPostResource.php`         |
+| `app/Models/`                          | Eloquent models: casts, relationships, role/verification helpers, query scopes.                     | `app/Models/CleaningJobPost.php`                         |
+| `app/Enums/`                           | Backed enums for fixed value sets.                                                                  | `app/Enums/ApplicationStatus.php`                        |
+| `app/Policies/`                        | Per-model authorization policies (auto-discovered, no manual registration).                         | `app/Policies/ApplicationPolicy.php`                     |
 | `app/Notifications/`                   | Mailables/notifications, e.g. queued email verification.                                            | `app/Notifications/Auth/QueuedVerifyEmail.php`           |
 | `app/Providers/AppServiceProvider.php` | Global auth wiring: admin `Gate::before`, SPA reset-link URL, default password policy.              | `app/Providers/AppServiceProvider.php`                   |
 | `bootstrap/app.php`                    | Route registration, global middleware, and the rule that `/api/*` errors render as JSON.            | `bootstrap/app.php`                                      |
 | `config/`                              | Framework config plus app-specific config.                                                          | `config/cleanhub.php`, `config/cors.php`                 |
-| `database/migrations/`                 | Schema definitions. The `users` table carries the `role` enum column.                               | `database/migrations/0001_01_01_000000_create_users_table.php` |
-| `database/factories/`                  | Test/seed data builders, including role states.                                                    | `database/factories/UserFactory.php`                     |
-| `database/seeders/`                    | Seeders; the single admin is seeded here.                                                           | `database/seeders/AdminUserSeeder.php`                   |
-| `tests/Feature/`, `tests/Unit/`        | Pest tests, grouped by area. Most are feature (HTTP-level) tests.                                   | `tests/Feature/Auth/RegistrationTest.php`                |
+| `database/migrations/`                 | Schema definitions. The `users` table carries the `role` enum column; every job-related table is prefixed `cleaning_` (see below). | `database/migrations/0001_01_01_000000_create_users_table.php` |
+| `database/factories/`                  | Test/seed data builders, including role and status states.                                          | `database/factories/CleaningJobPostFactory.php`          |
+| `database/seeders/`                    | Seeders; the single admin and the fixed category list are seeded here, plus local-only demo data.   | `database/seeders/AdminUserSeeder.php`                   |
+| `tests/Feature/`, `tests/Unit/`        | Pest tests, grouped by area. Most are feature (HTTP-level) tests.                                   | `tests/Feature/ApplicationTest.php`                      |
 
 ## Key decisions
 
@@ -37,13 +37,59 @@ verify things see [`testing.md`](testing.md).
 | API versioning under `/v1`                                   | Lets breaking changes ship later under `/v2` without breaking existing clients.                             | `Route::prefix('v1')` in `routes/api.php`; controllers namespaced `App\Http\Controllers\Api\V1`.                                   |
 | Role stored as an enum on the `users` table                  | Each user has exactly one role from a fixed set — one column beats a join table; a PHP enum adds type safety.| `role` enum column in the users migration; `App\Enums\UserRole` cast on `User`; `RegisterRequest` limits self-registration.        |
 | Admin is a super-user, and exactly one admin exists          | The admin has full control and is never self-registered.                                                     | `Gate::before` in `AppServiceProvider` grants admin every ability; `AdminUserSeeder` is idempotent and keyed on the admin role.    |
-| Prefer soft deletes for admin-facing destructive actions     | Destructive admin actions should be recoverable and auditable, not permanent.                               | Project-wide convention (root `CLAUDE.md`). No such action exists yet; affected models will use the `SoftDeletes` trait.           |
+| Prefer soft deletes for admin-facing destructive actions     | Destructive admin actions should be recoverable and auditable, not permanent.                               | `CleaningJobPost` uses `SoftDeletes`; its `DELETE` endpoint is admin-only via a policy that denies everyone else outright (the admin's `Gate::before` bypass is the sole path through). |
 | Frontend/backend split for email links                       | Verification is a backend concern (verify, then redirect to SPA); reset needs the SPA to collect the password.| `VerifyEmailController` redirects to `FRONTEND_URL?verified=1`; `ResetPassword::createUrlUsing` (in `AppServiceProvider`) targets `FRONTEND_URL/reset-password`. |
+| Job-related tables are prefixed `cleaning_`, never bare `jobs` | Laravel's own queue system already owns a `jobs` table (`0001_01_01_000002_create_jobs_table.php`) — reusing that name would collide. | `cleaning_job_posts`, `cleaning_job_categories` migrations; `CleaningJobPost`/`CleaningJobCategory` models. |
+| `visibility` and `status` are two separate columns on a job post, never merged | They answer different questions — is this live yet, versus where is it in its lifecycle — and merging them would make "draft but somehow closed" representable when it shouldn't be. | `CleaningJobPost` casts both to their own enum; `UpdateCleaningJobPostRequest` locks `status` while a post is a draft and locks everything else once published. |
+| A published job post's status only moves forward, never back or sideways | The lifecycle (`open → reviewing → closed → completed`) models real-world progress; letting it move backward would let an employer un-complete a job after cleaners have already been paid or rated. | `UpdateCleaningJobPostRequest::forwardOnlyStatus()`, a validation closure comparing the requested status against a fixed order map. |
+| A cleaner's viewer-specific flags (`is_saved`, `has_applied`, `application_status`) are attached via query scopes, not per-row lookups | A list of 50 job posts would otherwise need 100+ extra queries (one saved-check and one applied-check per row) just to render badges. | `CleaningJobPost::scopeWithViewerSaved()` / `scopeWithViewerApplication()` — each adds one `withExists`/`withMax` subquery to the whole list's query, not one query per row. |
+| An application row is never deleted, only moved through statuses | The unique `(cleaning_job_post_id, user_id)` constraint is what permanently blocks a second application to the same job — deleting a withdrawn/rejected row would silently reopen that door. | `Application` migration's unique index; `ApplicationController::destroy()` (withdraw) and `JobApplicantController::decide()` (accept/reject) both call `update()`, never `delete()`. |
+| Applying is gated on the cleaner role alone, with no separate "not your own job" check | Roles are fixed and mutually exclusive — the employer who owns a post can never also hold the cleaner role needed to apply, so a dedicated ownership check would guard a code path that can't be reached. | `ApplicationPolicy::create()`; `StoreApplicationRequest::authorize()`. |
+| A schedule conflict on apply is a `409`, not a `422` | It isn't that any single field is invalid — the request is only rejected because of something else the caller already committed to (an accepted job on an overlapping date). A distinct status code lets a client branch on it without parsing message text. | `ApplicationController::conflictsWithAcceptedSchedule()`; the `409` response shares the same `{message, errors}` shape as a `422` so existing field-error handling still works. |
+| No separate calendar table | Accepting an application is the only event that should ever put a job on a cleaner's calendar — a second table just to mirror that would be one more place for the two to drift out of sync. | `ApplicationController::calendar()` reads `Application` rows with `status` in `[accepted, completed]`, joined to their job post, directly. |
+| `per_page` has a floor of 50, not just a ceiling | Every list this API serves backs a feed or table the frontend wants filled in one round trip — a tiny page size would just mean more requests for the same total data. | `Controller::perPageRule()`, a shared helper every paginated list endpoint's validation calls into. |
+| `GET /cleaning-job-categories` and `GET /calendar` skip the pagination envelope entirely | Both return a small, bounded set the caller always wants in full (the whole category list; one cleaner's whole calendar) — wrapping them in `data`/`meta` would add structure with nothing to describe. | `JsonResource::withoutWrapping()` in `AppServiceProvider` — every *other* list endpoint stays wrapped because pagination always adds its own `data`/`meta`/`links`, independent of this setting; these two are the only unpaginated collections in the API, so they're the only ones it actually affects. |
 
 ## Domain model (current)
 
-Only one domain model exists so far; this section grows as tables are added.
-
 - **User** — `id`, `name`, `email`, `password`, `role` (`UserRole` enum:
   `cleaner`/`employer`/`moderator`/`admin`), `email_verified_at`, timestamps.
-  Implements `MustVerifyEmail`; holds Sanctum tokens via `HasApiTokens`.
+  Implements `MustVerifyEmail`; holds Sanctum tokens via `HasApiTokens`. A user
+  has exactly one role for its whole lifetime — there's no promotion path from
+  cleaner to employer or anything similar.
+
+- **CleanerProfile** / **EmployerProfile** — one-to-one with `User`, keyed on
+  `user_id`, created lazily on first read/write (`firstOrCreate()`) rather than
+  at registration time, so a fresh account doesn't need a placeholder row it
+  might never touch. `CleanerProfile` additionally has a many-to-many to
+  `CleaningJobCategory` (the categories a cleaner is willing to work in) via a
+  pivot table. Both store an array of `{name, path}` document records for
+  uploaded PDFs, appended to (never overwritten by) each profile update.
+
+- **CleaningJobCategory** — `id`, `name`, `slug`, `is_active`. An admin-managed
+  lookup table seeded with a fixed starting set (residential, hotel, hospital,
+  office, factory, event cleanup, public space, research facility). Deactivating
+  a category hides it from the pickable list without breaking any job post that
+  already references it.
+
+- **CleaningJobPost** — table `cleaning_job_posts` (see the naming decision
+  above), belongs to an `employer` (`User`) and a `CleaningJobCategory`. Carries
+  `visibility` (`draft`/`published`) and `status`
+  (`open`/`reviewing`/`closed`/`completed`/`removed`) as two independent enum
+  columns — see the key decisions table for why they're kept separate and why
+  `status` only moves forward. Also holds the schedule (`schedule_date`,
+  `start_time`, `end_time`), location, pay (display-only — see root project
+  notes on payment scope), and an array of `{name, path}` uploaded images.
+  Uses `SoftDeletes`.
+
+- **SavedJob** — a pivot between a cleaner (`User`) and a `CleaningJobPost`,
+  unique on `(user_id, cleaning_job_post_id)`. Exists purely to record "this
+  cleaner bookmarked this post" — no status of its own.
+
+- **Application** — belongs to a `CleaningJobPost` and a cleaner `User`.
+  `status` (`ApplicationStatus` enum: `pending`/`accepted`/`rejected`/
+  `withdrawn`/`completed`), an optional `message` from the cleaner and
+  `resume_path`, a `decision_message` the employer can write back (readable by
+  both sides), and a `private_note` visible to the employer alone. Unique on
+  `(cleaning_job_post_id, user_id)` — see the key decisions table for why this
+  row is never deleted once created.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,14 @@ simpler than digging through the log.
 | Login & logout    | `tests/Feature/Auth/AuthenticationTest.php`   | Tokens issue only for valid credentials and are genuinely revocable. |
 | Email verification| `tests/Feature/Auth/EmailVerificationTest.php`| Only the real email owner can verify; the link is unforgeable.       |
 | Password reset    | `tests/Feature/Auth/PasswordResetTest.php`    | Passwords change only with a genuine broker token.                   |
+| Categories        | `tests/Feature/CleaningJobCategoryTest.php`   | Only active categories are listed; guests can read them.             |
+| Job browsing       | `tests/Feature/CleaningJobPostBrowseTest.php` | The open/published default, the search-vs-passive-feed split, status filtering privilege, and pagination bounds. |
+| Job posting/updates| `tests/Feature/CleaningJobPostManageTest.php`, `tests/Feature/CleaningJobPostUpdateTest.php` | A draft's content stays fully editable; a published post locks content and only advances `status` forward. |
+| Job detail         | `tests/Feature/CleaningJobPostShowTest.php`   | A single post is visible to the public only when published/non-removed, plus the owner's own-state exception. |
+| Employer's public job history | `tests/Feature/EmployerJobListingTest.php` | `GET /employers/{id}/cleaning-job-posts` excludes drafts/removed posts and never leaks `applications_count`. |
+| Profiles           | `tests/Feature/ProfileTest.php`, `tests/Feature/PublicProfileTest.php` | A profile is created lazily on first access; `email` is owner-only; documents append rather than replace. |
+| Saved jobs         | `tests/Feature/SavedJobTest.php`              | Only open/published jobs can be saved; duplicate saves and cross-user unsaves are rejected; pagination bounds. |
+| Applications & calendar | `tests/Feature/ApplicationTest.php`      | Every apply-rejection rule (closed, duplicate, self-apply, schedule conflict), accept/reject/withdraw transitions, and that the calendar only ever shows accepted/completed jobs. |
 
 > Run a whole group with its file path (e.g.
 > `php artisan test tests/Feature/Auth/RegistrationTest.php`); narrow to a single
@@ -236,3 +244,210 @@ curl -s -X POST http://localhost:8000/api/v1/auth/login \
 
 **Expected:** step 1 → `200`; step 2 → `200`; step 3 → `422`; step 4 → `200` with
 a fresh token, proving the new password is live.
+
+### Job posts (browse, post, update, delete)
+
+**What it verifies & why:** the browse feed must default to `open`+`published`
+for everyone but the employer market-watching by status; a post's content must
+be editable while it's a draft and locked once published, with `status` moving
+forward only; and deleting a post must be an admin-only action, not something
+even the owning employer can do.
+
+**Run just these groups:**
+
+```bash
+php artisan test tests/Feature/CleaningJobPostBrowseTest.php
+php artisan test tests/Feature/CleaningJobPostManageTest.php
+php artisan test tests/Feature/CleaningJobPostUpdateTest.php
+php artisan test tests/Feature/CleaningJobPostShowTest.php
+php artisan test tests/Feature/EmployerJobListingTest.php
+```
+
+**Reproduce by hand** — register an employer and a cleaner first (see
+Registration above), then:
+
+```bash
+# 1. Employer posts a published, open job → expect 201
+curl -s -X POST http://localhost:8000/api/v1/cleaning-job-posts \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPLOYER_TOKEN" \
+  -d '{"title":"Hotel Housekeeping Team","cleaning_job_category_id":2,"description":"Looking for a reliable housekeeping team.","country":"Philippines","city":"Cebu City","schedule_date":"2026-09-15","start_time":"08:00","end_time":"16:00","cleaners_needed":3,"pay_amount":1500,"pay_currency":"PHP","visibility":"published"}'
+
+# 2. Cleaner browses the default feed → expect the new post included, is_saved/has_applied both false
+curl -s "http://localhost:8000/api/v1/cleaning-job-posts?per_page=50" \
+  -H "Accept: application/json" -H "Authorization: Bearer CLEANER_TOKEN"
+
+# 3. Cleaner tries to filter by status → expect 422 on the status field
+curl -s "http://localhost:8000/api/v1/cleaning-job-posts?status=open" \
+  -H "Accept: application/json" -H "Authorization: Bearer CLEANER_TOKEN"
+
+# 4. Employer advances the post's status → expect 200, status now "reviewing"
+curl -s -X PATCH http://localhost:8000/api/v1/cleaning-job-posts/PASTE_JOB_ID \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPLOYER_TOKEN" \
+  -d '{"status":"reviewing"}'
+
+# 5. Employer tries to edit a locked (published) field → expect 422
+curl -s -X PATCH http://localhost:8000/api/v1/cleaning-job-posts/PASTE_JOB_ID \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPLOYER_TOKEN" \
+  -d '{"title":"New Title"}'
+
+# 6. Employer tries to delete their own post → expect 403
+curl -s -X DELETE http://localhost:8000/api/v1/cleaning-job-posts/PASTE_JOB_ID \
+  -H "Accept: application/json" -H "Authorization: Bearer EMPLOYER_TOKEN"
+
+# 7. Log in as the seeded admin and delete it → expect 200
+curl -s -X POST http://localhost:8000/api/v1/auth/login \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -d '{"email":"admin@cleanhub.test","password":"password"}'
+curl -s -X DELETE http://localhost:8000/api/v1/cleaning-job-posts/PASTE_JOB_ID \
+  -H "Accept: application/json" -H "Authorization: Bearer ADMIN_TOKEN"
+```
+
+(`admin@cleanhub.test` / `password` are the local defaults from
+`config/cleanhub.php` — override `ADMIN_EMAIL`/`ADMIN_PASSWORD` in `.env` before
+seeding anywhere real users could reach it.)
+
+**Expected:** step 1 → `201`; step 2 → `200` with the post listed; step 3 →
+`422`; step 4 → `200` with `status: "reviewing"`; step 5 → `422`; step 6 →
+`403`; step 7's login → `200`, then delete → `200`.
+
+### Saved jobs
+
+**What it verifies & why:** only a currently open/published job can be saved,
+a job can't be saved twice, and a saved job that later closes stays on the list
+(never silently filtered out).
+
+**Run just this group:**
+
+```bash
+php artisan test tests/Feature/SavedJobTest.php
+```
+
+**Reproduce by hand:**
+
+```bash
+# 1. Cleaner saves the job → expect 201
+curl -s -X POST http://localhost:8000/api/v1/saved-jobs \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_JOB_ID}'
+
+# 2. Save it again → expect 422 "already in your saved list"
+curl -s -X POST http://localhost:8000/api/v1/saved-jobs \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_JOB_ID}'
+
+# 3. Unsave it → expect 200
+curl -s -X DELETE http://localhost:8000/api/v1/saved-jobs/PASTE_JOB_ID \
+  -H "Accept: application/json" -H "Authorization: Bearer CLEANER_TOKEN"
+```
+
+**Expected:** step 1 → `201`; step 2 → `422`; step 3 → `200`.
+
+### Applications & calendar
+
+**What it verifies & why:** the entire apply lifecycle — a cleaner can apply
+once and only once to an open job (closed-job and duplicate rejections are both
+`422`s but with different messages), an employer can never apply to their own
+listing (a `403` before validation even runs), a schedule that overlaps an
+already-accepted job is rejected as a `409` rather than a `422`, and accepting
+an application is the one and only thing that puts a job on the cleaner's
+calendar.
+
+**Run just this group:**
+
+```bash
+php artisan test tests/Feature/ApplicationTest.php
+```
+
+**Reproduce by hand** — continuing with the job from the section above (still
+`open`/`published`; re-post one if it was advanced/deleted earlier):
+
+```bash
+# 1. Cleaner applies with a message → expect 201, status "pending"
+curl -s -X POST http://localhost:8000/api/v1/applications \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_JOB_ID, "message": "I have five years of hotel housekeeping experience."}'
+
+# 2. Same cleaner applies again → expect 422 "already applied"
+curl -s -X POST http://localhost:8000/api/v1/applications \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_JOB_ID}'
+
+# 3. The employer who posted it tries to apply to their own job → expect 403
+curl -s -X POST http://localhost:8000/api/v1/applications \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPLOYER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_JOB_ID}'
+
+# 4. Employer views the applicant list → expect 201's application listed
+curl -s http://localhost:8000/api/v1/cleaning-job-posts/PASTE_JOB_ID/applications \
+  -H "Accept: application/json" -H "Authorization: Bearer EMPLOYER_TOKEN"
+
+# 5. Employer accepts it → expect 200, status "accepted"
+curl -s -X PATCH http://localhost:8000/api/v1/applications/PASTE_APPLICATION_ID/accept \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer EMPLOYER_TOKEN" \
+  -d '{"message": "You are booked in — see you on site at 8am."}'
+
+# 6. Cleaner checks their calendar → expect the now-accepted job listed
+curl -s http://localhost:8000/api/v1/calendar \
+  -H "Accept: application/json" -H "Authorization: Bearer CLEANER_TOKEN"
+
+# 7. Cleaner applies to a second job on the same date/overlapping time → expect 409
+curl -s -X POST http://localhost:8000/api/v1/applications \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"cleaning_job_post_id": PASTE_OVERLAPPING_JOB_ID}'
+```
+
+**Expected:** step 1 → `201`; step 2 → `422`; step 3 → `403`; step 4 → `200`
+with the application listed; step 5 → `200` with `status: "accepted"`; step 6
+→ `200` with a bare array containing that job; step 7 → `409`.
+
+To also exercise withdraw and reject: apply to a fresh job
+(`POST /applications`), then `DELETE /applications/{id}` while it's still
+`pending` → expect `200 { "message": "Application withdrawn." }`; separately,
+have the employer `PATCH /applications/{id}/reject` on a different pending
+application → expect `200` with `status: "rejected"`.
+
+### Profiles
+
+**What it verifies & why:** a profile exists (as an empty object) the first
+time it's read, without a separate creation step; only the profile's own owner
+ever sees its `email`; and uploaded documents accumulate rather than replace
+each other on every update.
+
+**Run just this group:**
+
+```bash
+php artisan test tests/Feature/ProfileTest.php
+php artisan test tests/Feature/PublicProfileTest.php
+```
+
+**Reproduce by hand:**
+
+```bash
+# 1. Cleaner reads their own (untouched) profile → expect 200, mostly-null fields
+curl -s http://localhost:8000/api/v1/profile \
+  -H "Accept: application/json" -H "Authorization: Bearer CLEANER_TOKEN"
+
+# 2. Cleaner updates bio/location/categories/languages → expect 200 with those fields set
+curl -s -X PATCH http://localhost:8000/api/v1/profile \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "Authorization: Bearer CLEANER_TOKEN" \
+  -d '{"bio":"Detail-oriented cleaner with hotel and residential experience.","country":"Philippines","city":"Cebu City","cleaning_categories":[1,2],"languages":["English","Cebuano"]}'
+
+# 3. The employer views the cleaner's public profile → expect 200, no email field
+curl -s http://localhost:8000/api/v1/cleaners/PASTE_CLEANER_USER_ID \
+  -H "Accept: application/json" -H "Authorization: Bearer EMPLOYER_TOKEN"
+```
+
+**Expected:** step 1 → `200`; step 2 → `200` reflecting the new values,
+`cleaning_categories` expanded to `{id, name, slug}` objects; step 3 → `200`
+with every field from step 2 except `email`.


### PR DESCRIPTION
- Document every endpoint shipped since the auth foundation: job categories, job posts, profiles, saved jobs, applications, and the calendar
- Add a Pagination convention section and the 409 status code to the standard error shapes
- Expand the domain model and key-decisions tables in the architecture guide with every model and pattern added since
- Extend the testing guide with a test-file reference table and hand-reproducible curl walkthroughs for the newly documented endpoints