### PR TITLE
Feat: Add lifecycle notifications for applications

### DIFF
--- a/app/Console/Commands/SendJobReminders.php
+++ b/app/Console/Commands/SendJobReminders.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Notifications\Applications\JobReminder;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+
+#[Signature('app:send-job-reminders')]
+#[Description('Notify cleaners of accepted jobs scheduled for tomorrow')]
+class SendJobReminders extends Command
+{
+    /**
+     * Every accepted application whose job is scheduled for tomorrow gets one
+     * reminder, checked against the notifications table itself (rather than a
+     * separate "sent" flag) so re-running the command the same day is safe.
+     */
+    public function handle(): int
+    {
+        $tomorrow = now()->addDay()->toDateString();
+
+        $applications = Application::query()
+            ->where('status', ApplicationStatus::Accepted)
+            ->whereHas('cleaningJobPost', fn (Builder $query) => $query->whereDate('schedule_date', $tomorrow))
+            ->with('cleaningJobPost', 'user')
+            ->get();
+
+        $sent = 0;
+
+        foreach ($applications as $application) {
+            $alreadySent = $application->user->notifications()
+                ->where('type', JobReminder::class)
+                ->where('data->application_id', $application->id)
+                ->exists();
+
+            if ($alreadySent) {
+                continue;
+            }
+
+            $application->user->notify(new JobReminder($application));
+            $sent++;
+        }
+
+        $this->info("Sent {$sent} job reminder(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -12,6 +12,8 @@ use App\Models\Application;
 use App\Models\CleaningJobPost;
 use App\Models\SavedJob;
 use App\Models\User;
+use App\Notifications\Applications\ApplicationWithdrawn;
+use App\Notifications\Applications\NewApplicant;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -134,6 +136,8 @@ class ApplicationController extends Controller
 
         $this->attachViewerFlags(new Collection([$application]), $request->user());
 
+        $post->employer->notify(new NewApplicant($application));
+
         return (new ApplicationResource($application))->response()->setStatusCode(201);
     }
 
@@ -146,6 +150,9 @@ class ApplicationController extends Controller
         Gate::authorize('withdraw', $application);
 
         $application->update(['status' => ApplicationStatus::Withdrawn]);
+
+        $application->load('cleaningJobPost.employer');
+        $application->cleaningJobPost->employer->notify(new ApplicationWithdrawn($application));
 
         return response()->json(['message' => 'Application withdrawn.']);
     }

--- a/app/Http/Controllers/Api/V1/JobApplicantController.php
+++ b/app/Http/Controllers/Api/V1/JobApplicantController.php
@@ -9,6 +9,8 @@ use App\Http\Requests\UpdateApplicationNoteRequest;
 use App\Http\Resources\ApplicationResource;
 use App\Models\Application;
 use App\Models\CleaningJobPost;
+use App\Notifications\Applications\ApplicationAccepted;
+use App\Notifications\Applications\ApplicationRejected;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\Gate;
@@ -114,7 +116,13 @@ class JobApplicantController extends Controller
             'decision_message' => $request->validated('message'),
         ]);
 
-        $application->load(['user.cleanerProfile']);
+        $application->load(['user.cleanerProfile', 'cleaningJobPost']);
+
+        $application->user->notify(
+            $status === ApplicationStatus::Accepted
+                ? new ApplicationAccepted($application)
+                : new ApplicationRejected($application),
+        );
 
         return new ApplicationResource($application);
     }

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\NotificationResource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class NotificationController extends Controller
+{
+    /**
+     * The authenticated user's own notifications, newest first, paginated.
+     * `unread_only` powers both the bell's badge count and its dropdown list
+     * with the same endpoint, just a different query string.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $validated = $request->validate([
+            'unread_only' => ['sometimes', 'boolean'],
+            'per_page' => $this->perPageRule(),
+        ]);
+
+        $notifications = $request->user()->notifications()
+            ->when(
+                $validated['unread_only'] ?? false,
+                fn (Builder $query) => $query->whereNull('read_at'),
+            )
+            ->paginate($validated['per_page'] ?? 50);
+
+        return NotificationResource::collection($notifications);
+    }
+
+    /**
+     * Mark one of the authenticated user's own notifications as read. Scoped
+     * through their own notifications() relation rather than a global route
+     * model bind, so requesting someone else's notification id 404s instead
+     * of leaking whether it exists.
+     */
+    public function markRead(Request $request, string $notification): NotificationResource
+    {
+        $record = $request->user()->notifications()->findOrFail($notification);
+        $record->markAsRead();
+
+        return new NotificationResource($record);
+    }
+
+    public function markAllRead(Request $request): JsonResponse
+    {
+        $request->user()->unreadNotifications()->update(['read_at' => now()]);
+
+        return response()->json(['message' => 'All notifications marked as read.']);
+    }
+}

--- a/app/Http/Resources/NotificationResource.php
+++ b/app/Http/Resources/NotificationResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Notifications\DatabaseNotification;
+
+/**
+ * @mixin DatabaseNotification
+ */
+class NotificationResource extends JsonResource
+{
+    /**
+     * Every notification's `data` array already carries `type` and `message`
+     * (see ApplicationNotification::toArray()) plus whichever resource ids
+     * that event relates to — flattened here rather than nested, since a
+     * client parses this the same way regardless of which event it is.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            ...$this->data,
+            'read_at' => $this->read_at,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/Notifications/Applications/ApplicationAccepted.php
+++ b/app/Notifications/Applications/ApplicationAccepted.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+class ApplicationAccepted extends ApplicationNotification
+{
+    protected function type(): string
+    {
+        return 'application_accepted';
+    }
+
+    protected function subject(): string
+    {
+        return 'Your application was accepted';
+    }
+
+    protected function message(): string
+    {
+        return sprintf(
+            'Your application for "%s" was accepted.',
+            $this->application->cleaningJobPost->title,
+        );
+    }
+}

--- a/app/Notifications/Applications/ApplicationNotification.php
+++ b/app/Notifications/Applications/ApplicationNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+use App\Models\Application;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Every application-lifecycle notification (accepted, rejected, a new
+ * applicant, a withdrawal, a schedule reminder) shares the same shape: it's
+ * about one application, goes out on the same two channels, and stores the
+ * same three fields. Only the wording and machine-readable `type` differ per
+ * event, so those are the only things a subclass supplies.
+ */
+abstract class ApplicationNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly Application $application) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject($this->subject())
+            ->line($this->message());
+    }
+
+    /**
+     * @return array{type: string, message: string, application_id: int, cleaning_job_post_id: int}
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => $this->type(),
+            'message' => $this->message(),
+            'application_id' => $this->application->id,
+            'cleaning_job_post_id' => $this->application->cleaning_job_post_id,
+        ];
+    }
+
+    abstract protected function type(): string;
+
+    abstract protected function subject(): string;
+
+    abstract protected function message(): string;
+}

--- a/app/Notifications/Applications/ApplicationRejected.php
+++ b/app/Notifications/Applications/ApplicationRejected.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+class ApplicationRejected extends ApplicationNotification
+{
+    protected function type(): string
+    {
+        return 'application_rejected';
+    }
+
+    protected function subject(): string
+    {
+        return 'An update on your application';
+    }
+
+    protected function message(): string
+    {
+        return sprintf(
+            'Your application for "%s" was not accepted this time.',
+            $this->application->cleaningJobPost->title,
+        );
+    }
+}

--- a/app/Notifications/Applications/ApplicationWithdrawn.php
+++ b/app/Notifications/Applications/ApplicationWithdrawn.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+class ApplicationWithdrawn extends ApplicationNotification
+{
+    protected function type(): string
+    {
+        return 'application_withdrawn';
+    }
+
+    protected function subject(): string
+    {
+        return 'An applicant withdrew';
+    }
+
+    protected function message(): string
+    {
+        return sprintf(
+            '%s withdrew their application for "%s".',
+            $this->application->user->name,
+            $this->application->cleaningJobPost->title,
+        );
+    }
+}

--- a/app/Notifications/Applications/JobReminder.php
+++ b/app/Notifications/Applications/JobReminder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+class JobReminder extends ApplicationNotification
+{
+    protected function type(): string
+    {
+        return 'job_reminder';
+    }
+
+    protected function subject(): string
+    {
+        return 'Upcoming job tomorrow';
+    }
+
+    protected function message(): string
+    {
+        return sprintf(
+            '"%s" is scheduled for tomorrow, %s.',
+            $this->application->cleaningJobPost->title,
+            $this->application->cleaningJobPost->schedule_date->toFormattedDateString(),
+        );
+    }
+}

--- a/app/Notifications/Applications/NewApplicant.php
+++ b/app/Notifications/Applications/NewApplicant.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Notifications\Applications;
+
+class NewApplicant extends ApplicationNotification
+{
+    protected function type(): string
+    {
+        return 'new_applicant';
+    }
+
+    protected function subject(): string
+    {
+        return 'New applicant for your job post';
+    }
+
+    protected function message(): string
+    {
+        return sprintf(
+            '%s applied to "%s".',
+            $this->application->user->name,
+            $this->application->cleaningJobPost->title,
+        );
+    }
+}

--- a/database/migrations/2026_08_07_040351_create_notifications_table.php
+++ b/database/migrations/2026_08_07_040351_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use App\Http\Controllers\Api\V1\CleaningJobPostController;
 use App\Http\Controllers\Api\V1\JobApplicantController;
+use App\Http\Controllers\Api\V1\NotificationController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\PublicProfileController;
 use App\Http\Controllers\Api\V1\RatingController;
@@ -84,6 +85,10 @@ Route::prefix('v1')->group(function (): void {
             ->whereNumber('application');
         Route::patch('applications/{application}/note', [JobApplicantController::class, 'note'])
             ->whereNumber('application');
+
+        Route::get('notifications', [NotificationController::class, 'index']);
+        Route::patch('notifications/read-all', [NotificationController::class, 'markAllRead']);
+        Route::patch('notifications/{notification}/read', [NotificationController::class, 'markRead']);
     });
 
     Route::middleware('auth:sanctum')->get('/user', fn (Request $request) => $request->user());

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('app:send-job-reminders')->dailyAt('08:00');

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\User;
+use App\Notifications\Applications\ApplicationAccepted;
+use App\Notifications\Applications\ApplicationRejected;
+use App\Notifications\Applications\ApplicationWithdrawn;
+use App\Notifications\Applications\JobReminder;
+use App\Notifications\Applications\NewApplicant;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Sanctum\Sanctum;
+
+test('applying to a job notifies the employer', function () {
+    Notification::fake();
+    $employer = User::factory()->employer()->create();
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->postJson('/api/v1/applications', ['cleaning_job_post_id' => $post->id])->assertCreated();
+
+    Notification::assertSentTo($employer, NewApplicant::class);
+    Notification::assertNotSentTo($cleaner, NewApplicant::class);
+});
+
+test('withdrawing an application notifies the employer', function () {
+    Notification::fake();
+    $employer = User::factory()->employer()->create();
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id, 'user_id' => $cleaner->id]);
+    Sanctum::actingAs($cleaner);
+
+    $this->deleteJson("/api/v1/applications/{$application->id}")->assertOk();
+
+    Notification::assertSentTo($employer, ApplicationWithdrawn::class);
+});
+
+test('accepting an application notifies the cleaner', function () {
+    Notification::fake();
+    $employer = User::factory()->employer()->create();
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id, 'user_id' => $cleaner->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/accept", [])->assertOk();
+
+    Notification::assertSentTo($cleaner, ApplicationAccepted::class);
+});
+
+test('rejecting an application notifies the cleaner', function () {
+    Notification::fake();
+    $employer = User::factory()->employer()->create();
+    $cleaner = User::factory()->cleaner()->create();
+    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $application = Application::factory()->create(['cleaning_job_post_id' => $post->id, 'user_id' => $cleaner->id]);
+    Sanctum::actingAs($employer);
+
+    $this->patchJson("/api/v1/applications/{$application->id}/reject", [])->assertOk();
+
+    Notification::assertSentTo($cleaner, ApplicationRejected::class);
+});
+
+test('the reminder command notifies cleaners of accepted jobs scheduled tomorrow only', function () {
+    Notification::fake();
+    $tomorrowPost = CleaningJobPost::factory()->create(['schedule_date' => now()->addDay()->toDateString()]);
+    $nextWeekPost = CleaningJobPost::factory()->create(['schedule_date' => now()->addWeek()->toDateString()]);
+    $dueTomorrow = Application::factory()->status(ApplicationStatus::Accepted)->create(['cleaning_job_post_id' => $tomorrowPost->id]);
+    $dueNextWeek = Application::factory()->status(ApplicationStatus::Accepted)->create(['cleaning_job_post_id' => $nextWeekPost->id]);
+    $pendingTomorrow = Application::factory()->status(ApplicationStatus::Pending)->create(['cleaning_job_post_id' => $tomorrowPost->id]);
+
+    $this->artisan('app:send-job-reminders')->assertSuccessful();
+
+    Notification::assertSentTo($dueTomorrow->user, JobReminder::class);
+    Notification::assertNotSentTo($dueNextWeek->user, JobReminder::class);
+    Notification::assertNotSentTo($pendingTomorrow->user, JobReminder::class);
+});
+
+test('the reminder command does not double-send on a second run', function () {
+    $post = CleaningJobPost::factory()->create(['schedule_date' => now()->addDay()->toDateString()]);
+    $application = Application::factory()->status(ApplicationStatus::Accepted)->create(['cleaning_job_post_id' => $post->id]);
+
+    $this->artisan('app:send-job-reminders');
+    $this->artisan('app:send-job-reminders');
+
+    expect($application->user->notifications()->where('type', JobReminder::class)->count())->toBe(1);
+});
+
+test("a user's notification list only contains their own, newest first", function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $other = User::factory()->cleaner()->create();
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $other->notify(new JobReminder(Application::factory()->create(['user_id' => $other->id])));
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/notifications')->assertOk()->assertJsonCount(2, 'data');
+});
+
+test('unread_only narrows the list to notifications not yet read', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $cleaner->unreadNotifications()->first()->markAsRead();
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson('/api/v1/notifications?unread_only=1')->assertOk()->assertJsonCount(1, 'data');
+});
+
+test("a user can mark their own notification as read but not another user's", function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $other = User::factory()->cleaner()->create();
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $notification = $cleaner->notifications()->sole();
+    Sanctum::actingAs($cleaner);
+
+    $this->patchJson("/api/v1/notifications/{$notification->id}/read")
+        ->assertOk()
+        ->assertJsonPath('id', $notification->id);
+    expect($notification->fresh()->read_at)->not->toBeNull();
+
+    Sanctum::actingAs($other);
+    $this->patchJson("/api/v1/notifications/{$notification->id}/read")->assertNotFound();
+});
+
+test('mark-all-read clears every unread notification for the authenticated user', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    Sanctum::actingAs($cleaner);
+
+    $this->patchJson('/api/v1/notifications/read-all')->assertOk();
+
+    expect($cleaner->unreadNotifications()->count())->toBe(0);
+});
+
+test('a guest cannot read or manage notifications', function () {
+    $this->getJson('/api/v1/notifications')->assertUnauthorized();
+    $this->patchJson('/api/v1/notifications/read-all')->assertUnauthorized();
+});


### PR DESCRIPTION
## Summary

This PR adds an **in-app + email notification system** built on top of Laravel's database notification channel. Every significant moment in an application's lifecycle now triggers a queued notification to the appropriate party — the employer when a cleaner applies or withdraws, and the cleaner when their application is accepted or rejected. A dedicated Artisan command sends a **day-before job reminder** to every cleaner with an accepted booking scheduled for the following day, with an idempotency guard so the cron can be re-run safely.

All notifications are persisted to a `notifications` table (Laravel's standard schema) and exposed through a small read/mark-as-read API that the frontend polls for the unread badge count.

---

## What Changed

### Database

**Migration** — `create_notifications_table`: standard Laravel `notifications` schema — UUID primary key, polymorphic `notifiable` morph columns, `type` string, `data` text, nullable `read_at`, timestamps.

---

### Notifications (`app/Notifications/Applications/`)

An **abstract base class** `ApplicationNotification` owns all the shared wiring:

- Implements `ShouldQueue` (all notifications go through the queue)
- Uses `Queueable`
- `via()` returns `['mail', 'database']`
- `toMail()` delegates subject/body to abstract methods
- `toArray()` stores a flat structure: `type`, `message`, `application_id`, `cleaning_job_post_id`

Five concrete subclasses each supply only `type()`, `subject()`, and `message()`:

| Class | Type string | Recipient | Trigger |
|---|---|---|---|
| `NewApplicant` | `new_applicant` | Employer | Cleaner applies |
| `ApplicationWithdrawn` | `application_withdrawn` | Employer | Cleaner withdraws |
| `ApplicationAccepted` | `application_accepted` | Cleaner | Employer accepts |
| `ApplicationRejected` | `application_rejected` | Cleaner | Employer rejects |
| `JobReminder` | `job_reminder` | Cleaner | Scheduled command (day before job) |

---

### Artisan Command — `SendJobReminders`

`app:send-job-reminders` runs through every `Accepted` application whose job's `schedule_date` is tomorrow and sends a `JobReminder` notification. Idempotency is enforced by checking the `notifications` table for an existing row with the same `type` and `application_id` before dispatching — re-running the command the same day is safe.

**Cron schedule** — registered in `routes/console.php` to fire daily at 08:00:
```php
Schedule::command('app:send-job-reminders')->dailyAt('08:00');
```

---

### Notification API (`NotificationController`)

Three endpoints, all behind `auth:sanctum`:

| Method | URI | Action |
|--------|-----|--------|
| `GET` | `/api/v1/notifications` | List the authenticated user's notifications, newest first, paginated |
| `PATCH` | `/api/v1/notifications/read-all` | Mark all unread notifications as read |
| `PATCH` | `/api/v1/notifications/{notification}/read` | Mark one notification as read |

**`GET /api/v1/notifications`** accepts:
- `unread_only=1` — narrows to unread rows only (used by the frontend badge poller)
- `per_page` — defaults to 50; powers the full page with a lower value for the bell dropdown

`markRead` scopes the lookup through `$user->notifications()->findOrFail(...)` rather than a global route model bind — requesting another user's notification ID returns 404 without leaking its existence.

---

### `NotificationResource`

Flattens the `data` JSON column into the top-level response object alongside `id`, `read_at`, and `created_at`. Since `ApplicationNotification::toArray()` always stores `type`, `message`, `application_id`, and `cleaning_job_post_id`, the client can switch on `type` without any extra envelope unwrapping.

---

### Controller Patches

**`ApplicationController`** — two new dispatch calls added to existing methods:
- `store()` → `$post->employer->notify(new NewApplicant($application))` after saving
- `destroy()` → eager-loads `cleaningJobPost.employer`, then `notify(new ApplicationWithdrawn($application))`

**`JobApplicantController`** — `decide()` now eager-loads `cleaningJobPost` (needed for the notification message) and dispatches either `ApplicationAccepted` or `ApplicationRejected` depending on the resolved status.

---

### Tests — `NotificationTest.php` (143 lines)

| Test | What it covers |
|---|---|
| Applying notifies the employer | `NewApplicant` sent to employer, not to cleaner |
| Withdrawing notifies the employer | `ApplicationWithdrawn` sent to employer |
| Accepting notifies the cleaner | `ApplicationAccepted` sent to cleaner |
| Rejecting notifies the cleaner | `ApplicationRejected` sent to cleaner |
| Reminder command — only tomorrow's accepted | `JobReminder` sent for tomorrow, not next week, not pending |
| Reminder command — idempotency | A second run on the same day does not duplicate the notification |
| Notification list — user isolation | Only the requesting user's own notifications are returned |
| `unread_only` filter | Narrows results correctly after one is marked read |
| `markRead` — ownership | Own notification: 200 + `read_at` set. Another user's ID: 404 |
| `markAllRead` | All unread cleared; guest gets 401 |

---

## Notes for Reviewers

- All notification classes implement `ShouldQueue` — the queue worker must be running in production for notifications to deliver. A `QUEUE_CONNECTION=sync` `.env` value keeps tests synchronous without any extra setup.
- `markRead` intentionally scopes through the relation (not a global `findOrFail`) to avoid an information-leak 403/404 distinction.
- The reminder command's idempotency check reads from the `notifications` table (matching `type` + `application_id` in the JSON `data` column) — no separate boolean column needed on `applications`.
