### PR TITLE
Add independent completion proofs and refine ratings and notifications

### DIFF
--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
+use Illuminate\Validation\Rules\File;
 use RuntimeException;
 
 class ApplicationController extends Controller
@@ -158,6 +159,36 @@ class ApplicationController extends Controller
     }
 
     /**
+     * The cleaner marks their side of the job complete by uploading a proof file
+     * (photo or PDF). This is independent of the employer marking the job post
+     * complete — either side may complete their side first, and rating unlocks
+     * for each reviewer once *their own* side is done. Requires the application
+     * to be in the `accepted` state (enforced by the policy).
+     */
+    public function complete(Request $request, Application $application): ApplicationResource
+    {
+        Gate::authorize('complete', $application);
+
+        $request->validate([
+            'proof' => [
+                'required',
+                File::types(['jpg', 'jpeg', 'png', 'webp', 'gif', 'pdf'])->max(10 * 1024),
+            ],
+        ], [
+            'proof.required' => 'A proof file (photo or PDF) is required to mark the job as complete.',
+        ]);
+
+        $application->completion_proof_path = $this->storeProof($request->file('proof'));
+        $application->status = ApplicationStatus::Completed;
+        $application->save();
+
+        $application->load(['cleaningJobPost.employer', 'cleaningJobPost.category']);
+        $this->attachViewerFlags(new Collection([$application]), $request->user());
+
+        return new ApplicationResource($application);
+    }
+
+    /**
      * The embedded job posts are loaded through the application, so the viewer
      * flags CleaningJobPostResource reads are not set by a query scope here.
      * Every job in this list is applied to by the viewer by definition; saved
@@ -221,6 +252,20 @@ class ApplicationController extends Controller
 
         return $existingJob->start_time < $targetJob->end_time &&
                 $targetJob->start_time < $existingJob->end_time;
+    }
+
+    /**
+     * Store an uploaded proof file (photo or PDF) on the public disk.
+     */
+    protected function storeProof(\Illuminate\Http\UploadedFile $file): string
+    {
+        $path = $file->store('application-proofs', 'public');
+
+        if ($path === false) {
+            throw new RuntimeException('Failed to store uploaded proof file.');
+        }
+
+        return $path;
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -22,8 +22,8 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Rules\File;
+use Illuminate\Validation\ValidationException;
 use RuntimeException;
 
 class ApplicationController extends Controller
@@ -257,7 +257,7 @@ class ApplicationController extends Controller
     /**
      * Store an uploaded proof file (photo or PDF) on the public disk.
      */
-    protected function storeProof(\Illuminate\Http\UploadedFile $file): string
+    protected function storeProof(UploadedFile $file): string
     {
         $path = $file->store('application-proofs', 'public');
 

--- a/app/Http/Controllers/Api/V1/ApplicationController.php
+++ b/app/Http/Controllers/Api/V1/ApplicationController.php
@@ -208,13 +208,19 @@ class ApplicationController extends Controller
         return false;
     }
 
-    protected function timeWindowsOverlap(CleaningJobPost $a, CleaningJobPost $b): bool
+    protected function timeWindowsOverlap(CleaningJobPost $existingJob, CleaningJobPost $targetJob): bool
     {
-        if ($a->start_time === null || $a->end_time === null || $b->start_time === null || $b->end_time === null) {
+        if (
+            $existingJob->start_time === null ||
+            $existingJob->end_time === null ||
+            $targetJob->start_time === null ||
+            $targetJob->end_time === null
+        ) {
             return true;
         }
 
-        return $a->start_time < $b->end_time && $b->start_time < $a->end_time;
+        return $existingJob->start_time < $targetJob->end_time &&
+                $targetJob->start_time < $existingJob->end_time;
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -213,29 +213,26 @@ class CleaningJobPostController extends Controller
     /**
      * Update a job post owned by the authenticated employer. Only the fields
      * present are changed; uploaded media replaces the existing set.
+     *
+     * When transitioning to `completed`, the employer must upload a proof file
+     * (validated in UpdateCleaningJobPostRequest). Accepted applications are NOT
+     * automatically flipped to `completed` — each cleaner marks their own side
+     * independently via POST /applications/{id}/complete.
      */
     public function update(UpdateCleaningJobPostRequest $request, CleaningJobPost $cleaningJobPost): CleaningJobPostResource
     {
-        $wasCompleted = $cleaningJobPost->status === JobPostStatus::Completed;
-
-        $cleaningJobPost->fill($request->safe()->except('media'));
+        $cleaningJobPost->fill($request->safe()->except(['media', 'completion_proof']));
 
         if ($request->hasFile('media')) {
             $cleaningJobPost->media = $this->storeMedia($request->file('media'));
         }
 
-        $cleaningJobPost->save();
-
-        // Completing a post is what unlocks rating: every accepted applicant
-        // moves to `completed` alongside it, so each side has a completed
-        // application to rate the other about. Applications the employer never
-        // accepted (rejected/withdrawn) are not part of the completed job and
-        // stay as they are.
-        if (! $wasCompleted && $cleaningJobPost->status === JobPostStatus::Completed) {
-            $cleaningJobPost->applications()
-                ->where('status', ApplicationStatus::Accepted)
-                ->update(['status' => ApplicationStatus::Completed]);
+        // Store the employer's proof when they complete the job post.
+        if ($request->hasFile('completion_proof')) {
+            $cleaningJobPost->completion_proof_path = $this->storeOrFail($request->file('completion_proof'));
         }
+
+        $cleaningJobPost->save();
 
         $cleaningJobPost->load(['employer', 'category']);
         $cleaningJobPost->loadCount('applications');

--- a/app/Http/Controllers/Api/V1/CleaningJobPostController.php
+++ b/app/Http/Controllers/Api/V1/CleaningJobPostController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Enums\ApplicationStatus;
 use App\Enums\JobPostStatus;
 use App\Enums\JobPostVisibility;
 use App\Enums\UserRole;

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\IndexNotificationRequest;
 use App\Http\Resources\NotificationResource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -16,12 +17,9 @@ class NotificationController extends Controller
      * `unread_only` powers both the bell's badge count and its dropdown list
      * with the same endpoint, just a different query string.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(IndexNotificationRequest $request): AnonymousResourceCollection
     {
-        $validated = $request->validate([
-            'unread_only' => ['sometimes', 'boolean'],
-            'per_page' => $this->perPageRule(),
-        ]);
+        $validated = $request->validated();
 
         $notifications = $request->user()->notifications()
             ->when(

--- a/app/Http/Controllers/Api/V1/RatingController.php
+++ b/app/Http/Controllers/Api/V1/RatingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Enums\UserRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreRatingRequest;
@@ -18,11 +19,13 @@ use Illuminate\Validation\ValidationException;
 class RatingController extends Controller
 {
     /**
-     * Rate the other party of an application, once the job is completed. Both
-     * directions (cleaner→employer and employer→cleaner) are independent rows,
-     * so either party may call this once the application reaches `completed` —
-     * a job post only reaches that status after the employer marks it done,
-     * which is also what moves its accepted applications to `completed`.
+     * Rate the other party of a job, once the reviewer's own side is completed.
+     * Each side unlocks independently:
+     *   - Cleaner rating the employer: their application must be `completed`
+     *   - Employer rating the cleaner: the job post must be `completed`
+     *
+     * The policy enforces this per-role; the controller only handles the
+     * duplicate-review guard and the reviewee derivation.
      */
     public function store(StoreRatingRequest $request): RatingResource
     {
@@ -30,14 +33,24 @@ class RatingController extends Controller
 
         Gate::authorize('review', [Rating::class, $application]);
 
-        if ($application->status !== ApplicationStatus::Completed) {
+        $reviewerId = $request->user()->id;
+        $isCleaner = $request->user()->isCleaner();
+
+        // Role-aware completion guard (policy already enforces this, but an
+        // explicit check here produces a clearer 422 message for API clients).
+        if ($isCleaner && $application->status !== ApplicationStatus::Completed) {
             throw ValidationException::withMessages([
-                'application_id' => 'You can only rate a job once it is completed.',
+                'application_id' => 'You can only rate the employer after marking your application as complete.',
             ]);
         }
 
-        $reviewerId = $request->user()->id;
-        $revieweeId = $reviewerId === $application->user_id
+        if (! $isCleaner && $application->cleaningJobPost->status !== JobPostStatus::Completed) {
+            throw ValidationException::withMessages([
+                'application_id' => 'You can only rate a cleaner after marking the job post as completed.',
+            ]);
+        }
+
+        $revieweeId = $isCleaner
             ? $application->cleaningJobPost->employer_id
             : $application->user_id;
 
@@ -54,13 +67,13 @@ class RatingController extends Controller
 
         $rating = Rating::create([
             'application_id' => $application->id,
-            'reviewer_id' => $reviewerId,
-            'reviewee_id' => $revieweeId,
-            'stars' => $request->validated('stars'),
-            'text' => $request->validated('text'),
+            'reviewer_id'    => $reviewerId,
+            'reviewee_id'    => $revieweeId,
+            'stars'          => $request->validated('stars'),
+            'text'           => $request->validated('text'),
         ]);
 
-        $rating->load('reviewer');
+        $rating->load(['reviewer', 'reviewee', 'application.cleaningJobPost']);
 
         return new RatingResource($rating);
     }
@@ -94,7 +107,7 @@ class RatingController extends Controller
         $ratings = Rating::query()
             ->where('reviewee_id', $reviewee->id)
             ->visible()
-            ->with('reviewer')
+            ->with(['reviewer', 'reviewee', 'application.cleaningJobPost'])
             ->latest()
             ->paginate($validated['per_page'] ?? 50);
 

--- a/app/Http/Controllers/Api/V1/RatingController.php
+++ b/app/Http/Controllers/Api/V1/RatingController.php
@@ -67,10 +67,10 @@ class RatingController extends Controller
 
         $rating = Rating::create([
             'application_id' => $application->id,
-            'reviewer_id'    => $reviewerId,
-            'reviewee_id'    => $revieweeId,
-            'stars'          => $request->validated('stars'),
-            'text'           => $request->validated('text'),
+            'reviewer_id' => $reviewerId,
+            'reviewee_id' => $revieweeId,
+            'stars' => $request->validated('stars'),
+            'text' => $request->validated('text'),
         ]);
 
         $rating->load(['reviewer', 'reviewee', 'application.cleaningJobPost']);

--- a/app/Http/Requests/IndexNotificationRequest.php
+++ b/app/Http/Requests/IndexNotificationRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexNotificationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'unread_only' => ['sometimes', 'boolean'],
+            'per_page' => ['sometimes', 'integer', 'min:50', 'max:200'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('unread_only')) {
+            return;
+        }
+
+        $unreadOnly = match ($this->input('unread_only')) {
+            'true' => true,
+            'false' => false,
+            default => null,
+        };
+
+        if ($unreadOnly !== null) {
+            $this->merge(['unread_only' => $unreadOnly]);
+        }
+    }
+}

--- a/app/Http/Requests/UpdateCleaningJobPostRequest.php
+++ b/app/Http/Requests/UpdateCleaningJobPostRequest.php
@@ -74,9 +74,15 @@ class UpdateCleaningJobPostRequest extends FormRequest
     protected function publishedRules(CleaningJobPost $post): array
     {
         $locked = ['prohibited'];
+        $isCompleting = $this->input('status') === JobPostStatus::Completed->value;
 
         return [
             'status' => ['sometimes', Rule::enum(JobPostStatus::class)->except(JobPostStatus::Removed), $this->forwardOnlyStatus($post)],
+            // A proof file (photo or PDF) is required when marking the job completed.
+            // It is forbidden in all other status transitions.
+            'completion_proof' => $isCompleting
+                ? ['required', File::types(['jpg', 'jpeg', 'png', 'webp', 'gif', 'pdf'])->max(10 * 1024)]
+                : ['prohibited'],
             'title' => $locked,
             'cleaning_job_category_id' => $locked,
             'description' => $locked,
@@ -105,6 +111,7 @@ class UpdateCleaningJobPostRequest extends FormRequest
         return [
             'prohibited' => 'A published job post is locked; only its status can be changed.',
             'status.prohibited' => "A job post's status cannot be changed until it is published.",
+            'completion_proof.required' => 'A proof file (photo or PDF) is required to mark the job as completed.',
         ];
     }
 

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Models\Application;
 use App\Models\Rating;
 use App\Models\User;
@@ -38,7 +39,7 @@ class ApplicationResource extends JsonResource
                 fn (): CleaningJobPostResource => new CleaningJobPostResource($this->cleaningJobPost),
             ),
             // Indicates whether the employer has also marked the job post as completed.
-            'job_completed' => $this->cleaningJobPost?->status?->value === 'completed',
+            'job_completed' => $this->cleaningJobPost->status === JobPostStatus::Completed,
             'cleaner' => $this->when(
                 $viewer?->isEmployer() === true,
                 fn (): array => $this->cleanerSummary(),
@@ -74,7 +75,7 @@ class ApplicationResource extends JsonResource
         }
 
         // Employer side: job post must be completed.
-        return $this->cleaningJobPost?->status?->value === 'completed';
+        return $this->cleaningJobPost->status === JobPostStatus::Completed;
     }
 
     protected function viewerHasRated(?User $viewer): bool

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -31,10 +31,14 @@ class ApplicationResource extends JsonResource
             'status' => $this->status->value,
             'message' => $this->message,
             'resume_url' => $this->resume_path === null ? null : Storage::disk('public')->url($this->resume_path),
+            // The cleaner's completion proof URL — visible to both the cleaner and the employer.
+            'completion_proof_url' => $this->completion_proof_path === null ? null : Storage::disk('public')->url($this->completion_proof_path),
             'job' => $this->when(
                 $viewer?->isCleaner() === true,
                 fn (): CleaningJobPostResource => new CleaningJobPostResource($this->cleaningJobPost),
             ),
+            // Indicates whether the employer has also marked the job post as completed.
+            'job_completed' => $this->cleaningJobPost?->status?->value === 'completed',
             'cleaner' => $this->when(
                 $viewer?->isEmployer() === true,
                 fn (): array => $this->cleanerSummary(),
@@ -43,15 +47,34 @@ class ApplicationResource extends JsonResource
             // private_note it is readable by both sides.
             'decision_message' => $this->decision_message,
             'private_note' => $this->when($viewer?->isEmployer() === true, fn (): ?string => $this->private_note),
-            // Only meaningful once the job is completed — that's the only point
-            // either side is allowed to rate the other at all.
+            // Rating unlock is per-side:
+            //   - Cleaner: shown when their application is completed (they can rate the employer)
+            //   - Employer: shown when the job post is completed (they can rate the cleaner)
             'viewer_has_rated' => $this->when(
-                $this->status === ApplicationStatus::Completed,
+                $this->viewerCanRate($viewer),
                 fn (): bool => $this->viewerHasRated($viewer),
             ),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+    }
+
+    /**
+     * Whether the current viewer has unlocked their side for rating.
+     * Cleaners unlock when their application is completed; employers when the job post is.
+     */
+    protected function viewerCanRate(?User $viewer): bool
+    {
+        if ($viewer === null) {
+            return false;
+        }
+
+        if ($viewer->isCleaner()) {
+            return $this->status === ApplicationStatus::Completed;
+        }
+
+        // Employer side: job post must be completed.
+        return $this->cleaningJobPost?->status?->value === 'completed';
     }
 
     protected function viewerHasRated(?User $viewer): bool

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -62,7 +62,10 @@ class ApplicationResource extends JsonResource
 
         return array_key_exists('viewer_has_rated', $this->resource->getAttributes())
             ? (bool) $this->getAttribute('viewer_has_rated')
-            : Rating::query()->where('application_id', $this->id)->where('reviewer_id', $viewer->id)->exists();
+            : Rating::query()
+                ->where('application_id', $this->id)
+                ->where('reviewer_id', $viewer->id)
+                ->exists();
     }
 
     /**

--- a/app/Http/Resources/CleanerProfileResource.php
+++ b/app/Http/Resources/CleanerProfileResource.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Resources;
 
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Models\CleanerProfile;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -36,7 +38,10 @@ class CleanerProfileResource extends JsonResource
             'documents' => $this->mapDocuments(),
             'rating_average' => $this->ratingAverage(),
             'rating_count' => $this->ratingCount(),
-            'completed_jobs_count' => 0,
+            'completed_jobs_count' => $this->user->applications()
+                ->where('status', ApplicationStatus::Completed)
+                ->whereHas('cleaningJobPost', fn ($q) => $q->where('status', JobPostStatus::Completed))
+                ->count(),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/EmployerProfileResource.php
+++ b/app/Http/Resources/EmployerProfileResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Enums\JobPostStatus;
 use App\Models\EmployerProfile;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -36,7 +37,7 @@ class EmployerProfileResource extends JsonResource
             'documents' => $this->mapDocuments(),
             'rating_average' => $this->ratingAverage(),
             'rating_count' => $this->ratingCount(),
-            'posted_jobs_count' => 0,
+            'posted_jobs_count' => $this->user->jobPosts()->where('status', '!=', JobPostStatus::Removed->value)->count(),
             'completed_jobs_count' => 0,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,

--- a/app/Http/Resources/RatingResource.php
+++ b/app/Http/Resources/RatingResource.php
@@ -19,7 +19,7 @@ class RatingResource extends JsonResource
     public function toArray(Request $request): array
     {
         $application = $this->application;
-        $jobPost     = $application?->cleaningJobPost;
+        $jobPost = $application->cleaningJobPost;
 
         // The reviewer is the one who submitted this rating. Determine whether
         // the *other* party has completed their side:
@@ -27,40 +27,40 @@ class RatingResource extends JsonResource
         //     side is the employer's job post completion.
         //   - If the reviewer is the employer (rating the cleaner), the other
         //     side is the cleaner's application completion.
-        $reviewerIsTheCleaner = $application && $this->reviewer_id === $application->user_id;
+        $reviewerIsTheCleaner = $this->reviewer_id === $application->user_id;
 
         $otherSideCompleted = $reviewerIsTheCleaner
-            ? ($jobPost?->status === JobPostStatus::Completed)
-            : ($application?->status === ApplicationStatus::Completed);
+            ? $jobPost->status === JobPostStatus::Completed
+            : $application->status === ApplicationStatus::Completed;
 
         return [
-            'id'                   => $this->id,
-            'application_id'       => $this->application_id,
-            'stars'                => $this->stars,
-            'text'                 => $this->text,
-            'reviewer'             => [
-                'id'        => $this->reviewer->id,
+            'id' => $this->id,
+            'application_id' => $this->application_id,
+            'stars' => $this->stars,
+            'text' => $this->text,
+            'reviewer' => [
+                'id' => $this->reviewer->id,
                 'full_name' => $this->reviewer->name,
-                'role'      => $this->reviewer->role->value,
+                'role' => $this->reviewer->role->value,
             ],
-            'reviewee'             => [
-                'id'        => $this->reviewee->id,
+            'reviewee' => [
+                'id' => $this->reviewee->id,
                 'full_name' => $this->reviewee->name,
-                'role'      => $this->reviewee->role->value,
+                'role' => $this->reviewee->role->value,
             ],
             // Whether the other party in this job has marked their side done.
             // False means the review exists but the job is not yet bilaterally complete.
             'other_side_completed' => $otherSideCompleted,
             // Key job post details displayed alongside each review so the reader
             // has context for what job the review is about.
-            'job_post'             => $jobPost ? [
-                'id'            => $jobPost->id,
-                'title'         => $jobPost->title,
-                'schedule_date' => $jobPost->schedule_date?->toDateString(),
-                'city'          => $jobPost->city,
-                'country'       => $jobPost->country,
-            ] : null,
-            'created_at'           => $this->created_at,
+            'job_post' => [
+                'id' => $jobPost->id,
+                'title' => $jobPost->title,
+                'schedule_date' => $jobPost->schedule_date->toDateString(),
+                'city' => $jobPost->city,
+                'country' => $jobPost->country,
+            ],
+            'created_at' => $this->created_at,
         ];
     }
 }

--- a/app/Http/Resources/RatingResource.php
+++ b/app/Http/Resources/RatingResource.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Resources;
 
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Models\Rating;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -16,17 +18,49 @@ class RatingResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $application = $this->application;
+        $jobPost     = $application?->cleaningJobPost;
+
+        // The reviewer is the one who submitted this rating. Determine whether
+        // the *other* party has completed their side:
+        //   - If the reviewer is the cleaner (rating the employer), the other
+        //     side is the employer's job post completion.
+        //   - If the reviewer is the employer (rating the cleaner), the other
+        //     side is the cleaner's application completion.
+        $reviewerIsTheCleaner = $application && $this->reviewer_id === $application->user_id;
+
+        $otherSideCompleted = $reviewerIsTheCleaner
+            ? ($jobPost?->status === JobPostStatus::Completed)
+            : ($application?->status === ApplicationStatus::Completed);
+
         return [
-            'id' => $this->id,
-            'application_id' => $this->application_id,
-            'stars' => $this->stars,
-            'text' => $this->text,
-            'reviewer' => [
-                'id' => $this->reviewer->id,
+            'id'                   => $this->id,
+            'application_id'       => $this->application_id,
+            'stars'                => $this->stars,
+            'text'                 => $this->text,
+            'reviewer'             => [
+                'id'        => $this->reviewer->id,
                 'full_name' => $this->reviewer->name,
-                'role' => $this->reviewer->role->value,
+                'role'      => $this->reviewer->role->value,
             ],
-            'created_at' => $this->created_at,
+            'reviewee'             => [
+                'id'        => $this->reviewee->id,
+                'full_name' => $this->reviewee->name,
+                'role'      => $this->reviewee->role->value,
+            ],
+            // Whether the other party in this job has marked their side done.
+            // False means the review exists but the job is not yet bilaterally complete.
+            'other_side_completed' => $otherSideCompleted,
+            // Key job post details displayed alongside each review so the reader
+            // has context for what job the review is about.
+            'job_post'             => $jobPost ? [
+                'id'            => $jobPost->id,
+                'title'         => $jobPost->title,
+                'schedule_date' => $jobPost->schedule_date?->toDateString(),
+                'city'          => $jobPost->city,
+                'country'       => $jobPost->country,
+            ] : null,
+            'created_at'           => $this->created_at,
         ];
     }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -7,6 +7,7 @@ use App\Enums\RatingStatus;
 use Database\Factories\ApplicationFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -27,7 +28,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read User $user
  * @property-read CleaningJobPost $cleaningJobPost
- * @property-read \Illuminate\Database\Eloquent\Collection<int, Rating> $ratings
+ * @property-read Collection<int, Rating> $ratings
  */
 #[Fillable([
     'cleaning_job_post_id',

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Carbon;
  * @property ApplicationStatus $status
  * @property string|null $message
  * @property string|null $resume_path
+ * @property string|null $completion_proof_path
  * @property string|null $private_note
  * @property string|null $decision_message
  * @property Carbon|null $created_at
@@ -33,6 +34,7 @@ use Illuminate\Support\Carbon;
     'user_id',
     'message',
     'status',
+    'completion_proof_path',
     'decision_message',
 ])]
 class Application extends Model

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -25,6 +26,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read User $user
  * @property-read CleaningJobPost $cleaningJobPost
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Rating> $ratings
  */
 #[Fillable([
     'cleaning_job_post_id',
@@ -75,6 +77,14 @@ class Application extends Model
     }
 
     /**
+     * @return HasMany<Rating, $this>
+     */
+    public function ratings(): HasMany
+    {
+        return $this->hasMany(Rating::class);
+    }
+
+    /**
      * Expose the applying cleaner's rating average/count as
      * `cleaner_rating_average`/`cleaner_rating_count` via a single correlated
      * subquery per list, the same single-subquery-per-list approach as
@@ -108,11 +118,17 @@ class Application extends Model
      */
     public function scopeWithViewerHasRated(Builder $query, User $viewer): void
     {
+        /*
+        The same logic with this query builder, the latter one uses the relationship:
         $query->addSelect([
             'viewer_has_rated' => Rating::query()
                 ->selectRaw('count(*) > 0')
                 ->whereColumn('application_id', 'applications.id')
                 ->where('reviewer_id', $viewer->id),
         ]);
+        */
+        $query->withExists(['ratings as viewer_has_rated' => function (Builder $subQuery) use ($viewer): void {
+            $subQuery->where('reviewer_id', $viewer->id);
+        }]);
     }
 }

--- a/app/Models/CleaningJobPost.php
+++ b/app/Models/CleaningJobPost.php
@@ -36,6 +36,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $pay_amount
  * @property string|null $pay_currency
  * @property array<int, array{name: string, path: string}>|null $media
+ * @property string|null $completion_proof_path
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -61,6 +62,7 @@ use Illuminate\Support\Carbon;
     'pay_amount',
     'pay_currency',
     'media',
+    'completion_proof_path',
 ])]
 class CleaningJobPost extends Model
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -101,6 +101,26 @@ class User extends Authenticatable implements MustVerifyEmail
     }
 
     /**
+     * Job posts created by this user (employer role).
+     *
+     * @return HasMany<CleaningJobPost, $this>
+     */
+    public function jobPosts(): HasMany
+    {
+        return $this->hasMany(CleaningJobPost::class, 'employer_id');
+    }
+
+    /**
+     * Applications submitted by this user (cleaner role).
+     *
+     * @return HasMany<Application, $this>
+     */
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
+    }
+
+    /**
      * Ratings this user received, either as the cleaner or as the employer of
      * a completed application — the two directions are independent rows on
      * the same table, distinguished only by who the reviewee is.

--- a/app/Notifications/Applications/ApplicationWithdrawn.php
+++ b/app/Notifications/Applications/ApplicationWithdrawn.php
@@ -17,8 +17,7 @@ class ApplicationWithdrawn extends ApplicationNotification
     protected function message(): string
     {
         return sprintf(
-            '%s withdrew their application for "%s".',
-            $this->application->user->name,
+            'Someone withdrew their application for "%s".',
             $this->application->cleaningJobPost->title,
         );
     }

--- a/app/Policies/ApplicationPolicy.php
+++ b/app/Policies/ApplicationPolicy.php
@@ -71,4 +71,15 @@ class ApplicationPolicy
     {
         return $user->id === $application->cleaningJobPost->employer_id;
     }
+
+    /**
+     * The cleaner who submitted the application may mark their side of the job
+     * as complete — but only once it has been accepted by the employer. Withdrawn,
+     * rejected, or already-completed applications are not eligible.
+     */
+    public function complete(User $user, Application $application): bool
+    {
+        return $user->id === $application->user_id
+            && $application->status === ApplicationStatus::Accepted;
+    }
 }

--- a/app/Policies/RatingPolicy.php
+++ b/app/Policies/RatingPolicy.php
@@ -2,6 +2,8 @@
 
 namespace App\Policies;
 
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Models\Application;
 use App\Models\User;
 
@@ -23,12 +25,28 @@ class RatingPolicy
     }
 
     /**
-     * Only the two parties to an application may rate each other about it —
-     * the cleaner who applied and the employer who owns the job post.
+     * Only the two parties to an application may rate each other about it.
+     * Each side unlocks independently based on their own completion:
+     *   - Cleaner → employer: unlocked once the cleaner marks their application complete
+     *   - Employer → cleaner: unlocked once the employer marks the job post complete
+     *
+     * This way neither side can be forced to wait for the other to unlock rating.
      */
     public function review(User $user, Application $application): bool
     {
-        return $user->id === $application->user_id
+        $isParty = $user->id === $application->user_id
             || $user->id === $application->cleaningJobPost->employer_id;
+
+        if (! $isParty) {
+            return false;
+        }
+
+        // Cleaner rating the employer: their own application must be completed.
+        if ($user->id === $application->user_id) {
+            return $application->status === ApplicationStatus::Completed;
+        }
+
+        // Employer rating the cleaner: the job post must be completed.
+        return $application->cleaningJobPost->status === JobPostStatus::Completed;
     }
 }

--- a/database/migrations/2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
+++ b/database/migrations/2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
@@ -37,4 +37,3 @@ return new class extends Migration
         });
     }
 };
-

--- a/database/migrations/2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
+++ b/database/migrations/2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add completion proof paths to both tables in one migration:
+ *   - applications.completion_proof_path        → cleaner's proof file
+ *   - cleaning_job_posts.completion_proof_path  → employer's proof file
+ *
+ * Both are nullable so existing rows need no back-fill; they only become
+ * required at the point of marking each side completed (enforced in the
+ * controller, not the schema).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table): void {
+            $table->string('completion_proof_path')->nullable()->after('resume_path');
+        });
+
+        Schema::table('cleaning_job_posts', function (Blueprint $table): void {
+            $table->string('completion_proof_path')->nullable()->after('media');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table): void {
+            $table->dropColumn('completion_proof_path');
+        });
+
+        Schema::table('cleaning_job_posts', function (Blueprint $table): void {
+            $table->dropColumn('completion_proof_path');
+        });
+    }
+};
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -54,10 +54,10 @@ Route::prefix('v1')->group(function (): void {
         Route::patch('profile', [ProfileController::class, 'update']);
 
         Route::get('cleaners/{id}', [PublicProfileController::class, 'cleaner']);
+        Route::get('cleaners/{id}/ratings', [RatingController::class, 'forCleaner'])
+            ->whereNumber('id');
         Route::get('employers/{id}', [PublicProfileController::class, 'employer']);
         Route::get('employers/{id}/cleaning-job-posts', [CleaningJobPostController::class, 'forEmployer'])
-            ->whereNumber('id');
-        Route::get('cleaners/{id}/ratings', [RatingController::class, 'forCleaner'])
             ->whereNumber('id');
         Route::get('employers/{id}/ratings', [RatingController::class, 'forEmployer'])
             ->whereNumber('id');

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,11 @@ Route::prefix('v1')->group(function (): void {
         Route::post('applications', [ApplicationController::class, 'store']);
         Route::delete('applications/{application}', [ApplicationController::class, 'destroy'])
             ->whereNumber('application');
+        // Cleaner marks their side of the job as complete with proof (image/PDF).
+        // Separate from the employer's job-post status update to keep each side
+        // fully independent and focused.
+        Route::post('applications/{application}/complete', [ApplicationController::class, 'complete'])
+            ->whereNumber('application');
 
         Route::get('calendar', [ApplicationController::class, 'calendar']);
 

--- a/tests/Feature/CleaningJobPostUpdateTest.php
+++ b/tests/Feature/CleaningJobPostUpdateTest.php
@@ -55,17 +55,25 @@ test('media on a draft post is replaced on update', function () {
 });
 
 test('a published post can advance its status forward', function () {
+    Storage::fake('public');
     $employer = User::factory()->employer()->create();
     $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]); // published + open
 
     Sanctum::actingAs($employer);
 
-    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'completed'])
+    $this->post("/api/v1/cleaning-job-posts/{$post->id}", [
+        '_method' => 'PATCH',
+        'status' => 'completed',
+        'completion_proof' => UploadedFile::fake()->image('proof.jpg'),
+    ])
         ->assertOk()
         ->assertJsonPath('status', 'completed');
+
+    Storage::disk('public')->assertExists($post->refresh()->completion_proof_path);
 });
 
-test('completing a post moves its accepted applications to completed but leaves other statuses alone', function () {
+test('completing a post leaves application statuses unchanged', function () {
+    Storage::fake('public');
     $employer = User::factory()->employer()->create();
     $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
     $accepted = Application::factory()->status(ApplicationStatus::Accepted)->create(['cleaning_job_post_id' => $post->id]);
@@ -74,11 +82,15 @@ test('completing a post moves its accepted applications to completed but leaves 
 
     Sanctum::actingAs($employer);
 
-    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'completed'])
+    $this->post("/api/v1/cleaning-job-posts/{$post->id}", [
+        '_method' => 'PATCH',
+        'status' => 'completed',
+        'completion_proof' => UploadedFile::fake()->image('proof.jpg'),
+    ])
         ->assertOk()
         ->assertJsonPath('status', 'completed');
 
-    expect($accepted->refresh()->status)->toBe(ApplicationStatus::Completed);
+    expect($accepted->refresh()->status)->toBe(ApplicationStatus::Accepted);
     expect($rejected->refresh()->status)->toBe(ApplicationStatus::Rejected);
     expect($withdrawn->refresh()->status)->toBe(ApplicationStatus::Withdrawn);
 });
@@ -95,6 +107,7 @@ test('content edits on a published post are rejected', function () {
 });
 
 test('a closed post cannot reopen but can complete', function () {
+    Storage::fake('public');
     $employer = User::factory()->employer()->create();
     $post = CleaningJobPost::factory()->status(JobPostStatus::Closed)->create(['employer_id' => $employer->id]);
 
@@ -103,7 +116,11 @@ test('a closed post cannot reopen but can complete', function () {
     $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'open'])
         ->assertStatus(422)->assertJsonValidationErrors('status');
 
-    $this->patchJson("/api/v1/cleaning-job-posts/{$post->id}", ['status' => 'completed'])
+    $this->post("/api/v1/cleaning-job-posts/{$post->id}", [
+        '_method' => 'PATCH',
+        'status' => 'completed',
+        'completion_proof' => UploadedFile::fake()->image('proof.jpg'),
+    ])
         ->assertOk()->assertJsonPath('status', 'completed');
 });
 

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -9,7 +9,9 @@ use App\Notifications\Applications\ApplicationRejected;
 use App\Notifications\Applications\ApplicationWithdrawn;
 use App\Notifications\Applications\JobReminder;
 use App\Notifications\Applications\NewApplicant;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
 
 test('applying to a job notifies the employer', function () {
@@ -100,15 +102,75 @@ test("a user's notification list only contains their own, newest first", functio
     $this->getJson('/api/v1/notifications')->assertOk()->assertJsonCount(2, 'data');
 });
 
-test('unread_only narrows the list to notifications not yet read', function () {
+test('the notification morph migration preserves notifications created before aliases were enforced', function () {
+    $cleaner = User::factory()->cleaner()->create();
+    $notificationId = (string) Str::uuid();
+    DB::table('notifications')->insert([
+        'id' => $notificationId,
+        'type' => JobReminder::class,
+        'notifiable_type' => User::class,
+        'notifiable_id' => $cleaner->id,
+        'data' => json_encode([
+            'type' => 'job_reminder',
+            'message' => 'Your accepted job starts tomorrow.',
+            'application_id' => 1,
+            'cleaning_job_post_id' => 1,
+        ], JSON_THROW_ON_ERROR),
+        'read_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $migration = require database_path('migrations/2026_08_13_124236_normalize_notification_notifiable_types.php');
+    $migration->up();
+
+    Sanctum::actingAs($cleaner);
+    $this->getJson('/api/v1/notifications')
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $notificationId);
+});
+
+test('unread_only narrows the list to notifications not yet read', function (string $unreadOnly) {
     $cleaner = User::factory()->cleaner()->create();
     $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
     $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
     $cleaner->unreadNotifications()->first()->markAsRead();
     Sanctum::actingAs($cleaner);
 
-    $this->getJson('/api/v1/notifications?unread_only=1')->assertOk()->assertJsonCount(1, 'data');
-});
+    $this->getJson("/api/v1/notifications?unread_only={$unreadOnly}")
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+})->with([
+    'integer query flag' => '1',
+    'boolean query flag' => 'true',
+]);
+
+test('unread_only false includes read notifications', function (string $unreadOnly) {
+    $cleaner = User::factory()->cleaner()->create();
+    $cleaner->notify(new JobReminder(Application::factory()->create(['user_id' => $cleaner->id])));
+    $cleaner->notifications()->first()->markAsRead();
+    Sanctum::actingAs($cleaner);
+
+    $this->getJson("/api/v1/notifications?unread_only={$unreadOnly}")
+        ->assertOk()
+        ->assertJsonCount(1, 'data');
+})->with([
+    'integer query flag' => '0',
+    'boolean query flag' => 'false',
+]);
+
+test('unread_only rejects an invalid boolean value', function (string $unreadOnly) {
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson("/api/v1/notifications?unread_only={$unreadOnly}")
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('unread_only');
+})->with([
+    'arbitrary string' => 'not-a-boolean',
+    'truthy word' => 'yes',
+    'on value' => 'on',
+]);
 
 test("a user can mark their own notification as read but not another user's", function () {
     $cleaner = User::factory()->cleaner()->create();

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -9,7 +9,6 @@ use App\Notifications\Applications\ApplicationRejected;
 use App\Notifications\Applications\ApplicationWithdrawn;
 use App\Notifications\Applications\JobReminder;
 use App\Notifications\Applications\NewApplicant;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
 use Laravel\Sanctum\Sanctum;
@@ -109,35 +108,6 @@ test("a user's notification list only contains their own, newest first", functio
     Sanctum::actingAs($cleaner);
 
     $this->getJson('/api/v1/notifications')->assertOk()->assertJsonCount(2, 'data');
-});
-
-test('the notification morph migration preserves notifications created before aliases were enforced', function () {
-    $cleaner = User::factory()->cleaner()->create();
-    $notificationId = (string) Str::uuid();
-    DB::table('notifications')->insert([
-        'id' => $notificationId,
-        'type' => JobReminder::class,
-        'notifiable_type' => User::class,
-        'notifiable_id' => $cleaner->id,
-        'data' => json_encode([
-            'type' => 'job_reminder',
-            'message' => 'Your accepted job starts tomorrow.',
-            'application_id' => 1,
-            'cleaning_job_post_id' => 1,
-        ], JSON_THROW_ON_ERROR),
-        'read_at' => now(),
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
-
-    $migration = require database_path('migrations/2026_08_13_124236_normalize_notification_notifiable_types.php');
-    $migration->up();
-
-    Sanctum::actingAs($cleaner);
-    $this->getJson('/api/v1/notifications')
-        ->assertOk()
-        ->assertJsonCount(1, 'data')
-        ->assertJsonPath('data.0.id', $notificationId);
 });
 
 test('unread_only narrows the list to notifications not yet read', function (string $unreadOnly) {

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -37,7 +37,16 @@ test('withdrawing an application notifies the employer', function () {
 
     $this->deleteJson("/api/v1/applications/{$application->id}")->assertOk();
 
-    Notification::assertSentTo($employer, ApplicationWithdrawn::class);
+    Notification::assertSentTo(
+        $employer,
+        ApplicationWithdrawn::class,
+        function (ApplicationWithdrawn $notification) use ($cleaner, $employer, $post): bool {
+            $message = $notification->toArray($employer)['message'];
+
+            return $message === "Someone withdrew their application for \"{$post->title}\"."
+                && ! Str::contains($message, $cleaner->name);
+        },
+    );
 });
 
 test('accepting an application notifies the cleaner', function () {

--- a/tests/Feature/RatingTest.php
+++ b/tests/Feature/RatingTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
 use App\Enums\RatingStatus;
 use App\Models\Application;
 use App\Models\CleaningJobPost;
@@ -38,8 +39,10 @@ test('a cleaner can rate the employer of a completed job', function () {
 test('an employer can rate the cleaner of a completed job', function () {
     $employer = User::factory()->employer()->create();
     $cleaner = User::factory()->cleaner()->create();
-    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
-    $application = Application::factory()->status(ApplicationStatus::Completed)->create([
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Completed)->create([
+        'employer_id' => $employer->id,
+    ]);
+    $application = Application::factory()->status(ApplicationStatus::Accepted)->create([
         'cleaning_job_post_id' => $post->id,
         'user_id' => $cleaner->id,
     ]);
@@ -54,7 +57,7 @@ test('an employer can rate the cleaner of a completed job', function () {
     expect($rating->reviewee_id)->toBe($cleaner->id);
 });
 
-test('a rating is rejected before the job is completed', function (ApplicationStatus $status) {
+test('a cleaner cannot rate before completing their application', function (ApplicationStatus $status) {
     $cleaner = User::factory()->cleaner()->create();
     $post = CleaningJobPost::factory()->create();
     $application = Application::factory()->status($status)->create([
@@ -64,8 +67,7 @@ test('a rating is rejected before the job is completed', function (ApplicationSt
     Sanctum::actingAs($cleaner);
 
     $this->postJson('/api/v1/ratings', ['application_id' => $application->id, 'stars' => 5])
-        ->assertStatus(422)
-        ->assertJsonValidationErrors('application_id');
+        ->assertForbidden();
 
     expect(Rating::count())->toBe(0);
 })->with([ApplicationStatus::Pending, ApplicationStatus::Accepted, ApplicationStatus::Rejected, ApplicationStatus::Withdrawn]);
@@ -91,7 +93,9 @@ test('a reviewer cannot rate the same completed application twice', function () 
 test('both directions of the same completed application can be rated independently', function () {
     $employer = User::factory()->employer()->create();
     $cleaner = User::factory()->cleaner()->create();
-    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Completed)->create([
+        'employer_id' => $employer->id,
+    ]);
     $application = Application::factory()->status(ApplicationStatus::Completed)->create([
         'cleaning_job_post_id' => $post->id,
         'user_id' => $cleaner->id,
@@ -204,7 +208,9 @@ test('a guest cannot submit or list ratings', function () {
 test("an application's viewer_has_rated flag flips after the viewer submits, independently per side", function () {
     $employer = User::factory()->employer()->create();
     $cleaner = User::factory()->cleaner()->create();
-    $post = CleaningJobPost::factory()->create(['employer_id' => $employer->id]);
+    $post = CleaningJobPost::factory()->status(JobPostStatus::Completed)->create([
+        'employer_id' => $employer->id,
+    ]);
     $application = Application::factory()->status(ApplicationStatus::Completed)->create([
         'cleaning_job_post_id' => $post->id,
         'user_id' => $cleaner->id,


### PR DESCRIPTION
## Summary

This PR introduces independent completion workflows for cleaners and employers, including proof uploads, and aligns rating eligibility with each party’s completion state.

It also improves profile statistics, rating response context, notification filtering, and withdrawal-notification privacy.

## Changes

### Completion workflow

- Add `completion_proof_path` to applications and cleaning job posts.
- Add `POST /api/v1/applications/{application}/complete` for cleaner-side completion.
- Require cleaners to upload an image or PDF before completing an accepted application.
- Require employers to upload an image or PDF when marking a job post as completed.
- Limit completion-proof uploads to 10 MB.
- Store cleaner proofs in the public `application-proofs` directory.
- Store employer proofs through the existing public job-media storage flow.
- Stop automatically completing every accepted application when an employer completes a job post.
- Allow cleaners and employers to complete their respective sides independently.
- Expose completion-proof URLs and completion state through API resources.

### Ratings

- Enforce role-specific rating eligibility:
  - Cleaners can rate after their application is completed.
  - Employers can rate after the job post is completed.
- Add reviewee information to rating responses.
- Add job-post title, schedule, and location context to rating responses.
- Add `other_side_completed` so clients can identify ratings awaiting the other party’s completion.
- Eager-load rating relationships to avoid additional per-rating queries.
- Replace the raw viewer-rating subquery with an Eloquent relationship and `withExists()`.

### Profiles

- Return the actual number of non-removed job posts on employer profiles.
- Return the actual number of fully completed jobs on cleaner profiles.
- Add the required user relationships for job posts and applications.

### Notifications

- Accept both numeric and textual values for `unread_only`:
  - `1` and `true`
  - `0` and `false`
- Move notification index validation into `IndexNotificationRequest`.
- Remove cleaner names from application-withdrawal notifications.
- Use the anonymous withdrawal message:
  - `Someone withdrew their application for "{job title}".`

### Refactoring

- Rename schedule-overlap parameters to match the frontend terminology.
- Reorganize rating routes for consistency.
- Improve resource and query readability.

## API and database impact

### New endpoint

```http
POST /api/v1/applications/{application}/complete
Content-Type: multipart/form-data
```

Expected field:

```text
proof: image or PDF, maximum 10 MB
```

### Changed endpoint behavior

Completing a cleaning job post now requires a multipart `completion_proof` file.

Employer completion no longer automatically changes accepted applications to `completed`.

### Migration

```text
2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
```

The new columns are nullable, so existing records do not require a backfill.

## Deployment notes

1. Back up the database.
2. Run the new migration.
3. Confirm the public filesystem disk is writable and linked.
4. Deploy the backend changes.
5. Deploy the compatible frontend changes afterward.

## Testing

Executed:

```bash
php artisan test
```

Current result:

- 269 tests executed
- 258 passed
- 10 failed
- 1 error
- 934 assertions

## Rollback

1. Revert this PR or redeploy the previous backend revision.
2. Roll back the completion-proof migration:

```bash
php artisan migrate:rollback --path=database/migrations/2026_08_09_173104_add_completion_proof_path_to_applications_and_cleaning_job_posts.php
```

3. Before dropping the columns, retain any proof paths that are needed for auditing or cleanup.
4. Database rollback does not delete uploaded files. Any known orphaned proof files must be cleaned up separately.

Already completed applications, ratings, and job-post statuses are not automatically reverted.