### PR TITLE
Feat: Add employer overview API for Dashboard

### DIFF
--- a/app/Http/Controllers/Api/V1/Employer/OverviewController.php
+++ b/app/Http/Controllers/Api/V1/Employer/OverviewController.php
@@ -124,24 +124,29 @@ class OverviewController extends Controller
             ],
             'priority_jobs' => $priorityJobs->map(fn (CleaningJobPost $job): array => $this->jobData($job))->values(),
             'upcoming_jobs' => $upcomingJobs->map(fn (CleaningJobPost $job): array => $this->jobData($job))->values(),
-            'recent_applications' => $recentApplications->map(fn (Application $application): array => [
-                'id' => $application->id,
-                'status' => $application->status->value,
-                'created_at' => $application->created_at,
-                'cleaner' => [
-                    'id' => $application->user->id,
-                    'name' => $application->user->name,
-                    'rating_average' => $application->cleaner_rating_average !== null
-                        ? round((float) $application->cleaner_rating_average, 1)
-                        : null,
-                    'rating_count' => (int) ($application->cleaner_rating_count ?? 0),
-                ],
-                'job' => [
-                    'id' => $application->cleaningJobPost->id,
-                    'title' => $application->cleaningJobPost->title,
-                    'schedule_date' => $application->cleaningJobPost->schedule_date?->toDateString(),
-                ],
-            ])->values(),
+            'recent_applications' => $recentApplications->map(function (Application $application): array {
+                /** @var float|int|string|null $ratingAverage */
+                $ratingAverage = $application->getAttribute('cleaner_rating_average');
+
+                return [
+                    'id' => $application->id,
+                    'status' => $application->status->value,
+                    'created_at' => $application->created_at,
+                    'cleaner' => [
+                        'id' => $application->user->id,
+                        'name' => $application->user->name,
+                        'rating_average' => $ratingAverage !== null
+                            ? round((float) $ratingAverage, 1)
+                            : null,
+                        'rating_count' => (int) $application->getAttribute('cleaner_rating_count'),
+                    ],
+                    'job' => [
+                        'id' => $application->cleaningJobPost->id,
+                        'title' => $application->cleaningJobPost->title,
+                        'schedule_date' => $application->cleaningJobPost->schedule_date->toDateString(),
+                    ],
+                ];
+            })->values(),
             'performance' => $this->performance($employer, $range, $periodStart),
             'reputation' => [
                 'average_rating' => $this->averageRating($employer),
@@ -175,9 +180,17 @@ class OverviewController extends Controller
             ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as closed', [JobPostVisibility::Published->value, JobPostStatus::Closed->value])
             ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as completed', [JobPostVisibility::Published->value, JobPostStatus::Completed->value])
             ->selectRaw('sum(case when status = ? then 1 else 0 end) as removed', [JobPostStatus::Removed->value])
-            ->first();
+            ->firstOrFail();
 
-        return $this->integerCounts($counts, ['total', 'draft', 'open', 'reviewing', 'closed', 'completed', 'removed']);
+        return [
+            'total' => (int) $counts->getAttribute('total'),
+            'draft' => (int) $counts->getAttribute('draft'),
+            'open' => (int) $counts->getAttribute('open'),
+            'reviewing' => (int) $counts->getAttribute('reviewing'),
+            'closed' => (int) $counts->getAttribute('closed'),
+            'completed' => (int) $counts->getAttribute('completed'),
+            'removed' => (int) $counts->getAttribute('removed'),
+        ];
     }
 
     /**
@@ -194,9 +207,16 @@ class OverviewController extends Controller
             ->selectRaw('sum(case when status = ? then 1 else 0 end) as rejected', [ApplicationStatus::Rejected->value])
             ->selectRaw('sum(case when status = ? then 1 else 0 end) as withdrawn', [ApplicationStatus::Withdrawn->value])
             ->selectRaw('sum(case when status = ? then 1 else 0 end) as completed', [ApplicationStatus::Completed->value])
-            ->first();
+            ->firstOrFail();
 
-        return $this->integerCounts($counts, ['total', 'pending', 'accepted', 'rejected', 'withdrawn', 'completed']);
+        return [
+            'total' => (int) $counts->getAttribute('total'),
+            'pending' => (int) $counts->getAttribute('pending'),
+            'accepted' => (int) $counts->getAttribute('accepted'),
+            'rejected' => (int) $counts->getAttribute('rejected'),
+            'withdrawn' => (int) $counts->getAttribute('withdrawn'),
+            'completed' => (int) $counts->getAttribute('completed'),
+        ];
     }
 
     private function unratedCleanersCount(User $employer): int
@@ -315,10 +335,10 @@ class OverviewController extends Controller
         return [
             'id' => $job->id,
             'title' => $job->title,
-            'category' => $job->category?->name,
+            'category' => $job->category->name,
             'city' => $job->city,
             'country' => $job->country,
-            'schedule_date' => $job->schedule_date?->toDateString(),
+            'schedule_date' => $job->schedule_date->toDateString(),
             'application_deadline' => $job->application_deadline?->toDateString(),
             'visibility' => $job->visibility->value,
             'status' => $job->status->value,
@@ -334,16 +354,5 @@ class OverviewController extends Controller
         $average = Rating::query()->visible()->where('reviewee_id', $employer->id)->avg('stars');
 
         return $average !== null ? round((float) $average, 1) : null;
-    }
-
-    /**
-     * @param  array<int, string>  $keys
-     * @return array<string, int>
-     */
-    private function integerCounts(?object $counts, array $keys): array
-    {
-        return collect($keys)->mapWithKeys(fn (string $key): array => [
-            $key => (int) ($counts?->{$key} ?? 0),
-        ])->all();
     }
 }

--- a/app/Http/Controllers/Api/V1/Employer/OverviewController.php
+++ b/app/Http/Controllers/Api/V1/Employer/OverviewController.php
@@ -1,0 +1,349 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Employer;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
+use App\Enums\JobPostVisibility;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Employer\IndexOverviewRequest;
+use App\Http\Resources\NotificationResource;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\Rating;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Employer-scoped management, tracking, and analysis data in one request.
+ * Keeping these aggregates together avoids making the dashboard fan out to
+ * every job, application, rating, and notification endpoint independently.
+ */
+class OverviewController extends Controller
+{
+    public function show(IndexOverviewRequest $request): JsonResponse
+    {
+        /** @var User $employer */
+        $employer = $request->user();
+        $range = $request->validated('range', '30d');
+        $periodStart = $this->periodStart($range);
+        $today = CarbonImmutable::today();
+
+        $jobPipeline = $this->jobPipeline($employer);
+        $applicantPipeline = $this->applicantPipeline($employer);
+        $unratedCleaners = $this->unratedCleanersCount($employer);
+
+        $priorityJobs = CleaningJobPost::query()
+            ->where('employer_id', $employer->id)
+            ->whereNotIn('status', [JobPostStatus::Completed, JobPostStatus::Removed])
+            ->with('category:id,name')
+            ->withCount([
+                'applications',
+                'applications as pending_applications_count' => fn (Builder $query) => $query
+                    ->where('status', ApplicationStatus::Pending),
+                'applications as accepted_applications_count' => fn (Builder $query) => $query
+                    ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed]),
+            ])
+            ->orderByDesc('pending_applications_count')
+            ->orderByRaw('case when application_deadline is null then 1 else 0 end')
+            ->orderBy('application_deadline')
+            ->limit(5)
+            ->get();
+
+        $upcomingJobs = CleaningJobPost::query()
+            ->where('employer_id', $employer->id)
+            ->published()
+            ->whereDate('schedule_date', '>=', $today)
+            ->whereHas('applications', fn (Builder $query) => $query
+                ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed]))
+            ->with('category:id,name')
+            ->withCount(['applications as accepted_applications_count' => fn (Builder $query) => $query
+                ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed])])
+            ->orderBy('schedule_date')
+            ->limit(5)
+            ->get();
+
+        $upcomingJobsCount = CleaningJobPost::query()
+            ->where('employer_id', $employer->id)
+            ->published()
+            ->whereDate('schedule_date', '>=', $today)
+            ->whereHas('applications', fn (Builder $query) => $query
+                ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed]))
+            ->count();
+
+        $recentApplications = Application::query()
+            ->whereHas('cleaningJobPost', fn (Builder $query) => $query
+                ->where('employer_id', $employer->id))
+            ->with([
+                'user:id,name',
+                'cleaningJobPost:id,title,schedule_date',
+            ])
+            ->withCleanerRating()
+            ->latest()
+            ->limit(6)
+            ->get();
+
+        $recentNotifications = $employer->notifications()
+            ->latest()
+            ->limit(5)
+            ->get();
+
+        $unreadNotifications = $employer->unreadNotifications()->count();
+
+        return response()->json([
+            'summary' => [
+                'total_posts' => $jobPipeline['total'],
+                'active_posts' => $jobPipeline['open'] + $jobPipeline['reviewing'],
+                'pending_applicants' => $applicantPipeline['pending'],
+                'accepted_cleaners' => $applicantPipeline['accepted'] + $applicantPipeline['completed'],
+                'upcoming_jobs' => $upcomingJobsCount,
+                'completed_jobs' => $jobPipeline['completed'],
+            ],
+            'job_pipeline' => $jobPipeline,
+            'applicant_pipeline' => $applicantPipeline,
+            'attention' => [
+                'draft_posts' => $jobPipeline['draft'],
+                'pending_applications' => $applicantPipeline['pending'],
+                'closing_soon' => CleaningJobPost::query()
+                    ->where('employer_id', $employer->id)
+                    ->published()
+                    ->whereIn('status', [JobPostStatus::Open, JobPostStatus::Reviewing])
+                    ->whereBetween('application_deadline', [$today, $today->addDays(7)])
+                    ->count(),
+                'awaiting_completion' => CleaningJobPost::query()
+                    ->where('employer_id', $employer->id)
+                    ->where('status', JobPostStatus::Closed)
+                    ->whereDate('schedule_date', '<=', $today)
+                    ->count(),
+                'unrated_cleaners' => $unratedCleaners,
+                'unread_notifications' => $unreadNotifications,
+            ],
+            'priority_jobs' => $priorityJobs->map(fn (CleaningJobPost $job): array => $this->jobData($job))->values(),
+            'upcoming_jobs' => $upcomingJobs->map(fn (CleaningJobPost $job): array => $this->jobData($job))->values(),
+            'recent_applications' => $recentApplications->map(fn (Application $application): array => [
+                'id' => $application->id,
+                'status' => $application->status->value,
+                'created_at' => $application->created_at,
+                'cleaner' => [
+                    'id' => $application->user->id,
+                    'name' => $application->user->name,
+                    'rating_average' => $application->cleaner_rating_average !== null
+                        ? round((float) $application->cleaner_rating_average, 1)
+                        : null,
+                    'rating_count' => (int) ($application->cleaner_rating_count ?? 0),
+                ],
+                'job' => [
+                    'id' => $application->cleaningJobPost->id,
+                    'title' => $application->cleaningJobPost->title,
+                    'schedule_date' => $application->cleaningJobPost->schedule_date?->toDateString(),
+                ],
+            ])->values(),
+            'performance' => $this->performance($employer, $range, $periodStart),
+            'reputation' => [
+                'average_rating' => $this->averageRating($employer),
+                'rating_count' => Rating::query()->visible()->where('reviewee_id', $employer->id)->count(),
+                'completed_relationships' => Application::query()
+                    ->whereHas('cleaningJobPost', fn (Builder $query) => $query
+                        ->where('employer_id', $employer->id)
+                        ->where('status', JobPostStatus::Completed))
+                    ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed])
+                    ->count(),
+                'ratings_to_give' => $unratedCleaners,
+            ],
+            'notifications' => [
+                'unread_count' => $unreadNotifications,
+                'items' => NotificationResource::collection($recentNotifications)->resolve($request),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{total: int, draft: int, open: int, reviewing: int, closed: int, completed: int, removed: int}
+     */
+    private function jobPipeline(User $employer): array
+    {
+        $counts = CleaningJobPost::query()
+            ->where('employer_id', $employer->id)
+            ->selectRaw('count(*) as total')
+            ->selectRaw('sum(case when visibility = ? then 1 else 0 end) as draft', [JobPostVisibility::Draft->value])
+            ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as open', [JobPostVisibility::Published->value, JobPostStatus::Open->value])
+            ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as reviewing', [JobPostVisibility::Published->value, JobPostStatus::Reviewing->value])
+            ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as closed', [JobPostVisibility::Published->value, JobPostStatus::Closed->value])
+            ->selectRaw('sum(case when visibility = ? and status = ? then 1 else 0 end) as completed', [JobPostVisibility::Published->value, JobPostStatus::Completed->value])
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as removed', [JobPostStatus::Removed->value])
+            ->first();
+
+        return $this->integerCounts($counts, ['total', 'draft', 'open', 'reviewing', 'closed', 'completed', 'removed']);
+    }
+
+    /**
+     * @return array{total: int, pending: int, accepted: int, rejected: int, withdrawn: int, completed: int}
+     */
+    private function applicantPipeline(User $employer): array
+    {
+        $counts = Application::query()
+            ->whereHas('cleaningJobPost', fn (Builder $query) => $query
+                ->where('employer_id', $employer->id))
+            ->selectRaw('count(*) as total')
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as pending', [ApplicationStatus::Pending->value])
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as accepted', [ApplicationStatus::Accepted->value])
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as rejected', [ApplicationStatus::Rejected->value])
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as withdrawn', [ApplicationStatus::Withdrawn->value])
+            ->selectRaw('sum(case when status = ? then 1 else 0 end) as completed', [ApplicationStatus::Completed->value])
+            ->first();
+
+        return $this->integerCounts($counts, ['total', 'pending', 'accepted', 'rejected', 'withdrawn', 'completed']);
+    }
+
+    private function unratedCleanersCount(User $employer): int
+    {
+        return Application::query()
+            ->whereHas('cleaningJobPost', fn (Builder $query) => $query
+                ->where('employer_id', $employer->id)
+                ->where('status', JobPostStatus::Completed))
+            ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed])
+            ->whereDoesntHave('ratings', fn (Builder $query) => $query
+                ->where('reviewer_id', $employer->id))
+            ->count();
+    }
+
+    /**
+     * @return array<string, int|float|string|array<int, array{label: string, value: int}>>
+     */
+    private function performance(User $employer, string $range, ?CarbonImmutable $periodStart): array
+    {
+        $posts = CleaningJobPost::query()->where('employer_id', $employer->id);
+        $applications = Application::query()->whereHas('cleaningJobPost', fn (Builder $query) => $query
+            ->where('employer_id', $employer->id));
+
+        if ($periodStart !== null) {
+            $posts->where('created_at', '>=', $periodStart);
+            $applications->where('created_at', '>=', $periodStart);
+        }
+
+        $postsCreated = (clone $posts)->count();
+        $applicationsReceived = (clone $applications)->count();
+        $acceptedApplicants = (clone $applications)
+            ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed])
+            ->count();
+        $completedJobs = (clone $posts)->where('status', JobPostStatus::Completed)->count();
+        $filledPosts = (clone $posts)
+            ->whereHas('applications', fn (Builder $query) => $query
+                ->whereIn('status', [ApplicationStatus::Accepted, ApplicationStatus::Completed]))
+            ->count();
+
+        return [
+            'range' => $range,
+            'posts_created' => $postsCreated,
+            'applications_received' => $applicationsReceived,
+            'accepted_applicants' => $acceptedApplicants,
+            'completed_jobs' => $completedJobs,
+            'average_applicants_per_post' => $postsCreated > 0
+                ? round($applicationsReceived / $postsCreated, 1)
+                : 0,
+            'fill_rate' => $postsCreated > 0 ? round(($filledPosts / $postsCreated) * 100, 1) : 0,
+            'completion_rate' => $postsCreated > 0 ? round(($completedJobs / $postsCreated) * 100, 1) : 0,
+            'application_trend' => $this->applicationTrend($employer, $range, $periodStart),
+        ];
+    }
+
+    /**
+     * @return array<int, array{label: string, value: int}>
+     */
+    private function applicationTrend(User $employer, string $range, ?CarbonImmutable $periodStart): array
+    {
+        $monthly = $range === 'all';
+        $driver = DB::getDriverName();
+        $bucket = match (true) {
+            $driver === 'sqlite' && $monthly => "strftime('%Y-%m', applications.created_at)",
+            $driver === 'sqlite' => "strftime('%Y-%m-%d', applications.created_at)",
+            $monthly => "date_format(applications.created_at, '%Y-%m')",
+            default => 'date(applications.created_at)',
+        };
+
+        $query = Application::query()
+            ->join('cleaning_job_posts', 'cleaning_job_posts.id', '=', 'applications.cleaning_job_post_id')
+            ->where('cleaning_job_posts.employer_id', $employer->id)
+            ->whereNull('cleaning_job_posts.deleted_at')
+            ->selectRaw("{$bucket} as period, count(*) as total")
+            ->groupBy(DB::raw($bucket))
+            ->orderBy('period');
+
+        if ($periodStart !== null) {
+            $query->where('applications.created_at', '>=', $periodStart);
+        }
+
+        /** @var Collection<string, int> $counts */
+        $counts = $query->get()->mapWithKeys(fn (Application $row): array => [
+            (string) $row->getAttribute('period') => (int) $row->getAttribute('total'),
+        ]);
+
+        if ($monthly) {
+            return $counts->map(fn (int $value, string $label): array => compact('label', 'value'))->values()->all();
+        }
+
+        $start = $periodStart ?? CarbonImmutable::today();
+        $trend = [];
+
+        for ($date = $start; $date->lte(CarbonImmutable::today()); $date = $date->addDay()) {
+            $label = $date->toDateString();
+            $trend[] = ['label' => $label, 'value' => $counts->get($label, 0)];
+        }
+
+        return $trend;
+    }
+
+    private function periodStart(string $range): ?CarbonImmutable
+    {
+        return match ($range) {
+            '7d' => CarbonImmutable::today()->subDays(6),
+            '30d' => CarbonImmutable::today()->subDays(29),
+            '90d' => CarbonImmutable::today()->subDays(89),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jobData(CleaningJobPost $job): array
+    {
+        return [
+            'id' => $job->id,
+            'title' => $job->title,
+            'category' => $job->category?->name,
+            'city' => $job->city,
+            'country' => $job->country,
+            'schedule_date' => $job->schedule_date?->toDateString(),
+            'application_deadline' => $job->application_deadline?->toDateString(),
+            'visibility' => $job->visibility->value,
+            'status' => $job->status->value,
+            'cleaners_needed' => $job->cleaners_needed,
+            'applications_count' => (int) ($job->applications_count ?? 0),
+            'pending_applications_count' => (int) ($job->pending_applications_count ?? 0),
+            'accepted_applications_count' => (int) ($job->accepted_applications_count ?? 0),
+        ];
+    }
+
+    private function averageRating(User $employer): ?float
+    {
+        $average = Rating::query()->visible()->where('reviewee_id', $employer->id)->avg('stars');
+
+        return $average !== null ? round((float) $average, 1) : null;
+    }
+
+    /**
+     * @param  array<int, string>  $keys
+     * @return array<string, int>
+     */
+    private function integerCounts(?object $counts, array $keys): array
+    {
+        return collect($keys)->mapWithKeys(fn (string $key): array => [
+            $key => (int) ($counts?->{$key} ?? 0),
+        ])->all();
+    }
+}

--- a/app/Http/Requests/Employer/IndexOverviewRequest.php
+++ b/app/Http/Requests/Employer/IndexOverviewRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Employer;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class IndexOverviewRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        /** @var User|null $user */
+        $user = $this->user();
+
+        return $user?->isEmployer() === true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'range' => ['sometimes', 'string', Rule::in(['7d', '30d', '90d', 'all'])],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\V1\Auth\RegisterController;
 use App\Http\Controllers\Api\V1\Auth\VerifyEmailController;
 use App\Http\Controllers\Api\V1\CleaningJobCategoryController;
 use App\Http\Controllers\Api\V1\CleaningJobPostController;
+use App\Http\Controllers\Api\V1\Employer\OverviewController as EmployerOverviewController;
 use App\Http\Controllers\Api\V1\JobApplicantController;
 use App\Http\Controllers\Api\V1\Moderation\ReportModerationController;
 use App\Http\Controllers\Api\V1\NotificationController;
@@ -103,6 +104,10 @@ Route::prefix('v1')->group(function (): void {
         Route::get('notifications', [NotificationController::class, 'index']);
         Route::patch('notifications/read-all', [NotificationController::class, 'markAllRead']);
         Route::patch('notifications/{notification}/read', [NotificationController::class, 'markRead']);
+
+        Route::prefix('employer')->middleware('role:employer')->group(function (): void {
+            Route::get('overview', [EmployerOverviewController::class, 'show']);
+        });
 
         // Filing a report is open to any authenticated user; working the queue
         // it feeds is not — that lives behind the moderator/admin group below.

--- a/tests/Feature/EmployerOverviewTest.php
+++ b/tests/Feature/EmployerOverviewTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Enums\ApplicationStatus;
+use App\Enums\JobPostStatus;
+use App\Models\Application;
+use App\Models\CleaningJobPost;
+use App\Models\Rating;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    CarbonImmutable::setTestNow('2026-08-15 09:00:00');
+});
+
+afterEach(function () {
+    CarbonImmutable::setTestNow();
+});
+
+test('an employer with no posts receives the job-post empty dashboard', function () {
+    $employer = User::factory()->employer()->create();
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/employer/overview')
+        ->assertOk()
+        ->assertJsonPath('summary.total_posts', 0)
+        ->assertJsonPath('summary.active_posts', 0)
+        ->assertJsonPath('summary.pending_applicants', 0)
+        ->assertJsonPath('job_pipeline.draft', 0)
+        ->assertJsonPath('applicant_pipeline.total', 0)
+        ->assertJsonPath('attention.unrated_cleaners', 0)
+        ->assertJsonPath('performance.range', '30d')
+        ->assertJsonPath('performance.posts_created', 0)
+        ->assertJsonPath('reputation.average_rating', null)
+        ->assertJsonCount(0, 'priority_jobs')
+        ->assertJsonCount(0, 'upcoming_jobs')
+        ->assertJsonCount(0, 'recent_applications');
+
+});
+
+test('the overview scopes management and analysis data to the authenticated employer', function () {
+    $employer = User::factory()->employer()->create();
+    $otherEmployer = User::factory()->employer()->create();
+    $cleaner = User::factory()->cleaner()->create();
+
+    $draft = CleaningJobPost::factory()->draft()->for($employer, 'employer')->create();
+    $open = CleaningJobPost::factory()->for($employer, 'employer')->create([
+        'application_deadline' => '2026-08-17',
+        'schedule_date' => '2026-08-25',
+    ]);
+    $reviewing = CleaningJobPost::factory()->status(JobPostStatus::Reviewing)->for($employer, 'employer')->create([
+        'application_deadline' => null,
+        'schedule_date' => '2026-08-20',
+    ]);
+    $closed = CleaningJobPost::factory()->status(JobPostStatus::Closed)->for($employer, 'employer')->create([
+        'schedule_date' => '2026-08-14',
+    ]);
+    $completed = CleaningJobPost::factory()->status(JobPostStatus::Completed)->for($employer, 'employer')->create([
+        'schedule_date' => '2026-08-10',
+    ]);
+
+    Application::factory()->for($open, 'cleaningJobPost')->status(ApplicationStatus::Pending)->create();
+    Application::factory()->for($reviewing, 'cleaningJobPost')->status(ApplicationStatus::Accepted)->create();
+    Application::factory()->for($closed, 'cleaningJobPost')->status(ApplicationStatus::Rejected)->create();
+    $completedApplication = Application::factory()
+        ->for($completed, 'cleaningJobPost')
+        ->for($cleaner, 'user')
+        ->status(ApplicationStatus::Completed)
+        ->create();
+
+    Rating::factory()->create([
+        'application_id' => $completedApplication->id,
+        'reviewer_id' => $cleaner->id,
+        'reviewee_id' => $employer->id,
+        'stars' => 5,
+    ]);
+
+    $otherJob = CleaningJobPost::factory()->for($otherEmployer, 'employer')->create();
+    Application::factory()->count(2)->for($otherJob, 'cleaningJobPost')->create();
+
+    Sanctum::actingAs($employer);
+
+    $response = $this->getJson('/api/v1/employer/overview?range=30d')
+        ->assertOk()
+        ->assertJsonPath('summary.total_posts', 5)
+        ->assertJsonPath('summary.active_posts', 2)
+        ->assertJsonPath('summary.pending_applicants', 1)
+        ->assertJsonPath('summary.accepted_cleaners', 2)
+        ->assertJsonPath('summary.upcoming_jobs', 1)
+        ->assertJsonPath('summary.completed_jobs', 1)
+        ->assertJsonPath('job_pipeline.draft', 1)
+        ->assertJsonPath('job_pipeline.open', 1)
+        ->assertJsonPath('job_pipeline.reviewing', 1)
+        ->assertJsonPath('job_pipeline.closed', 1)
+        ->assertJsonPath('job_pipeline.completed', 1)
+        ->assertJsonPath('applicant_pipeline.total', 4)
+        ->assertJsonPath('applicant_pipeline.pending', 1)
+        ->assertJsonPath('applicant_pipeline.accepted', 1)
+        ->assertJsonPath('applicant_pipeline.rejected', 1)
+        ->assertJsonPath('applicant_pipeline.completed', 1)
+        ->assertJsonPath('attention.draft_posts', 1)
+        ->assertJsonPath('attention.closing_soon', 1)
+        ->assertJsonPath('attention.awaiting_completion', 1)
+        ->assertJsonPath('attention.unrated_cleaners', 1)
+        ->assertJsonPath('performance.posts_created', 5)
+        ->assertJsonPath('performance.applications_received', 4)
+        ->assertJsonPath('reputation.average_rating', 5)
+        ->assertJsonPath('reputation.rating_count', 1)
+        ->assertJsonPath('reputation.completed_relationships', 1)
+        ->assertJsonPath('upcoming_jobs.0.id', $reviewing->id);
+
+    expect(collect($response->json('priority_jobs'))->pluck('id'))
+        ->toContain($draft->id, $open->id, $reviewing->id, $closed->id)
+        ->not->toContain($completed->id, $otherJob->id);
+    expect(collect($response->json('recent_applications'))->pluck('job.id')->unique()->all())
+        ->not->toContain($otherJob->id);
+});
+
+test('performance ranges filter older activity and reject unsupported values', function () {
+    $employer = User::factory()->employer()->create();
+
+    CleaningJobPost::factory()->for($employer, 'employer')->create([
+        'created_at' => '2026-08-14 09:00:00',
+    ]);
+    CleaningJobPost::factory()->for($employer, 'employer')->create([
+        'created_at' => '2026-07-01 09:00:00',
+    ]);
+
+    Sanctum::actingAs($employer);
+
+    $this->getJson('/api/v1/employer/overview?range=7d')
+        ->assertOk()
+        ->assertJsonPath('performance.posts_created', 1)
+        ->assertJsonCount(7, 'performance.application_trend');
+
+    $this->getJson('/api/v1/employer/overview?range=quarter')
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('range');
+});
+
+test('the employer overview requires authentication and the employer role', function () {
+    $this->getJson('/api/v1/employer/overview')->assertUnauthorized();
+
+    Sanctum::actingAs(User::factory()->cleaner()->create());
+
+    $this->getJson('/api/v1/employer/overview')->assertForbidden();
+});


### PR DESCRIPTION
## Summary

Add an authenticated, employer-scoped overview endpoint for the employer management dashboard.

The endpoint consolidates job, applicant, schedule, performance, reputation, and notification data into one response so the frontend does not need to fan out across multiple list endpoints.

## Changes

- Add `GET /api/v1/employer/overview`
- Restrict the endpoint to authenticated employers
- Add overview ranges for:
  - Last 7 days
  - Last 30 days
  - Last 90 days
  - All time
- Return employer-scoped summary metrics
- Return job-post and applicant pipelines
- Return attention counts for:
  - Draft posts
  - Pending applications
  - Approaching application deadlines
  - Jobs awaiting completion
  - Outstanding cleaner ratings
  - Unread notifications
- Return priority and upcoming job posts
- Return recent applicant activity
- Return hiring-performance metrics and application trends
- Return employer rating and completed-relationship information
- Return recent notifications
- Base the empty-dashboard response exclusively on whether the employer has job posts
- Add validation and feature coverage for authorization, isolation, empty states, and ranges

## API response consumers

This endpoint is consumed by the corresponding `cleanhub-react` employer dashboard PR.

## Verification

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact`
- 272 tests passed
- 1,003 assertions passed

## Rollback

Revert this PR to remove the employer overview route, request validation, controller, and feature tests. No migration or database rollback is required.